### PR TITLE
LTV HUD: fix button interaction, wire XR input, integrate LtvInstructionService

### DIFF
--- a/Assets/DummyLtvErrors.json
+++ b/Assets/DummyLtvErrors.json
@@ -1,0 +1,25 @@
+{
+  "errors": [
+    {
+      "code": "4155",
+      "description": "Main Power Bus Error",
+      "needs_resolved": true,
+      "procedures": [
+        "1. Locate the power distribution bus on the right side of the main control panel",
+        "2. Verify the primary switch is set to the OFF position",
+        "3. Engage the backup relay and wait for the green indicator light"
+      ]
+    },
+    {
+      "code": "4761",
+      "description": "Dust Sensor Error",
+      "needs_resolved": true,
+      "procedures": [
+        "1. Open the exterior sensor hatch",
+        "2. Use the compressed air canister to clear debris from the lens",
+        "3. Run recalibration sequence on the terminal"
+      ]
+    }
+  ]
+}
+

--- a/Assets/LTV/ButtonColorTest.cs
+++ b/Assets/LTV/ButtonColorTest.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ButtonColorTest : MonoBehaviour
+{
+    public Image background;
+
+    private void Start()
+    {
+        Debug.Log("[ButtonColorTest] Script is running. Press Space to turn background red.");
+    }
+
+    private void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Space))
+        {
+            OnButtonClicked();
+        }
+    }
+
+    public void OnButtonClicked()
+    {
+        Debug.Log("[ButtonColorTest] OnButtonClicked fired!");
+        background.color = Color.red;
+    }
+}

--- a/Assets/LTV/ControllerButtonInteraction.cs
+++ b/Assets/LTV/ControllerButtonInteraction.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.XR;
+
+/// <summary>
+/// Reads the ML controller ray directly and invokes registered buttons
+/// when the trigger is pressed while the ray intersects the button's rect.
+/// Attach this to any persistent GameObject (e.g. the Canvas).
+/// </summary>
+public class ControllerButtonInteraction : MonoBehaviour
+{
+    [System.Serializable]
+    public struct ButtonEntry
+    {
+        public Button button;
+        public RectTransform rectTransform;
+    }
+
+    [Header("Buttons to interact with")]
+    public List<ButtonEntry> buttons;
+
+    [Header("Debug")]
+    public bool enableDebugLogs = true;
+
+    private readonly List<InputDevice> _allDevices = new List<InputDevice>();
+    private bool _wasPressed;
+    private float _diagnosticTimer;
+
+    private void Start()
+    {
+        Debug.Log("[ControllerButtonInteraction] Script started.");
+    }
+
+    private void Update()
+    {
+        // Periodic diagnostics: log all found devices every 3 seconds
+        _diagnosticTimer += Time.deltaTime;
+        if (_diagnosticTimer >= 3f)
+        {
+            _diagnosticTimer = 0f;
+            LogDeviceDiagnostics();
+        }
+
+        // Try all devices — no characteristic filter so we don't miss anything
+        InputDevices.GetDevices(_allDevices);
+
+        bool isPressed = false;
+        Vector3 rayOrigin = Vector3.zero;
+        Vector3 rayDirection = Vector3.forward;
+
+        foreach (InputDevice device in _allDevices)
+        {
+            // Try triggerButton
+            bool triggerHeld = false;
+            device.TryGetFeatureValue(CommonUsages.triggerButton, out triggerHeld);
+
+            // Also try primaryButton as fallback (bumper/menu on ML2)
+            bool primaryHeld = false;
+            device.TryGetFeatureValue(CommonUsages.primaryButton, out primaryHeld);
+
+            if (!triggerHeld && !primaryHeld)
+                continue;
+
+            isPressed = true;
+
+            device.TryGetFeatureValue(CommonUsages.devicePosition, out rayOrigin);
+            Quaternion rotation = Quaternion.identity;
+            device.TryGetFeatureValue(CommonUsages.deviceRotation, out rotation);
+            rayDirection = rotation * Vector3.forward;
+
+            if (enableDebugLogs)
+                Debug.Log($"[ControllerButtonInteraction] Input detected on '{device.name}' " +
+                          $"trigger={triggerHeld} primary={primaryHeld} " +
+                          $"pos={rayOrigin} dir={rayDirection}");
+            break;
+        }
+
+        if (isPressed && !_wasPressed)
+        {
+            TryClick(rayOrigin, rayDirection);
+        }
+
+        _wasPressed = isPressed;
+    }
+
+    private void TryClick(Vector3 origin, Vector3 direction)
+    {
+        Ray ray = new Ray(origin, direction);
+
+        if (enableDebugLogs)
+            Debug.Log($"[ControllerButtonInteraction] TryClick ray origin={origin} dir={direction}");
+
+        foreach (ButtonEntry entry in buttons)
+        {
+            if (entry.button == null || entry.rectTransform == null)
+            {
+                Debug.LogWarning("[ControllerButtonInteraction] Button entry has null references.");
+                continue;
+            }
+
+            bool interactable = entry.button.interactable;
+            bool hits = RayHitsRect(ray, entry.rectTransform);
+
+            if (enableDebugLogs)
+                Debug.Log($"[ControllerButtonInteraction] Checking '{entry.button.name}' " +
+                          $"interactable={interactable} rayHits={hits}");
+
+            if (!interactable || !hits)
+                continue;
+
+            Debug.Log($"[ControllerButtonInteraction] >>> INVOKING onClick on '{entry.button.name}'");
+            entry.button.onClick.Invoke();
+            return;
+        }
+
+        if (enableDebugLogs)
+            Debug.Log("[ControllerButtonInteraction] No button was hit.");
+    }
+
+    private static bool RayHitsRect(Ray ray, RectTransform rect)
+    {
+        Plane plane = new Plane(rect.forward, rect.position);
+
+        float distance;
+        if (!plane.Raycast(ray, out distance) || distance <= 0f)
+            return false;
+
+        Vector3 hitWorld = ray.GetPoint(distance);
+        Vector3 hitLocal = rect.InverseTransformPoint(hitWorld);
+
+        Rect bounds = rect.rect;
+        return bounds.Contains(new Vector2(hitLocal.x, hitLocal.y));
+    }
+
+    private void LogDeviceDiagnostics()
+    {
+        if (!enableDebugLogs) return;
+
+        InputDevices.GetDevices(_allDevices);
+
+        if (_allDevices.Count == 0)
+        {
+            Debug.Log("[ControllerButtonInteraction] No XR devices found.");
+            return;
+        }
+
+        foreach (InputDevice device in _allDevices)
+        {
+            device.TryGetFeatureValue(CommonUsages.triggerButton, out bool trigger);
+            device.TryGetFeatureValue(CommonUsages.devicePosition, out Vector3 pos);
+            Debug.Log($"[ControllerButtonInteraction] Device: '{device.name}' " +
+                      $"characteristics={device.characteristics} " +
+                      $"trigger={trigger} pos={pos}");
+        }
+
+        // Also log button rect info
+        foreach (ButtonEntry entry in buttons)
+        {
+            if (entry.rectTransform == null) continue;
+            Debug.Log($"[ControllerButtonInteraction] Button '{entry.button?.name}' " +
+                      $"worldPos={entry.rectTransform.position} " +
+                      $"forward={entry.rectTransform.forward} " +
+                      $"rect={entry.rectTransform.rect}");
+        }
+    }
+}

--- a/Assets/LTV/LtvHudController.cs
+++ b/Assets/LTV/LtvHudController.cs
@@ -6,7 +6,7 @@ using LtvDiagnostics;
 public class LtvHudController : MonoBehaviour
 {
     [Header("Backend Service")]
-    public LtvErrorQueueService queueService;
+    public LtvInstructionService queueService;
 
     [Header("UI Elements")]
     public TextMeshProUGUI errorCodeText;   // The left box (formerly "AG NAV")
@@ -21,9 +21,6 @@ public class LtvHudController : MonoBehaviour
             queueService.StepChanged += OnStepChanged;
             queueService.ErrorChanged += OnErrorChanged;
             queueService.AllErrorsResolved += OnAllResolved;
-            
-            // Listen for button clicks
-            checkmarkButton.onClick.AddListener(OnCheckmarkClicked);
         }
     }
 
@@ -35,8 +32,6 @@ public class LtvHudController : MonoBehaviour
             queueService.StepChanged -= OnStepChanged;
             queueService.ErrorChanged -= OnErrorChanged;
             queueService.AllErrorsResolved -= OnAllResolved;
-            
-            checkmarkButton.onClick.RemoveListener(OnCheckmarkClicked);
         }
     }
 
@@ -51,7 +46,7 @@ public class LtvHudController : MonoBehaviour
     }
 
     // 3. When the right-hand button is clicked...
-    private void OnCheckmarkClicked()
+    public void OnCheckmarkClicked()
     {
         // Only advance if a diagnosis is active and we aren't waiting on TSS verification
         if (queueService != null && queueService.IsDiagnosisActive && !queueService.IsVerifying)

--- a/Assets/Scenes/LTV-HUD.unity
+++ b/Assets/Scenes/LTV-HUD.unity
@@ -423,8 +423,10 @@ GameObject:
   - component: {fileID: 476612519}
   - component: {fileID: 476612522}
   - component: {fileID: 476612521}
-  - component: {fileID: 476612520}
   - component: {fileID: 476612523}
+  - component: {fileID: 476612524}
+  - component: {fileID: 476612526}
+  - component: {fileID: 476612527}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -445,30 +447,13 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 962975831}
-  m_Father: {fileID: 1822070908}
+  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0.35}
   m_SizeDelta: {x: 512.5, y: 438}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &476612520
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 476612518}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
 --- !u!114 &476612521
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -527,10 +512,65 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 28f3595f2ab6b40feae409f01d4fddd0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  queueService: {fileID: 1773227991}
+  queueService: {fileID: 1773227994}
   errorCodeText: {fileID: 375528245}
   instructionText: {fileID: 321373841}
   checkmarkButton: {fileID: 760095030}
+--- !u!114 &476612524
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476612518}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a2d7d89889b4d94fa1f8d6fe49788e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Target: {fileID: 1822070908}
+  m_TargetOffset: {x: 0, y: 0.4, z: 2}
+  m_FollowInLocalSpace: 0
+  m_ApplyTargetInLocalSpace: 0
+  m_MovementSpeed: 6
+  m_MovementSpeedVariancePercentage: 0.25
+  m_SnapOnEnable: 1
+  m_PositionFollowMode: 1
+  m_MinDistanceAllowed: 0.01
+  m_MaxDistanceAllowed: 0.3
+  m_TimeUntilThresholdReachesMaxDistance: 3
+  m_RotationFollowMode: 1
+  m_MinAngleAllowed: 0.1
+  m_MaxAngleAllowed: 5
+  m_TimeUntilThresholdReachesMaxAngle: 3
+--- !u!114 &476612526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476612518}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 02e29eabfb89d44fb93e6c58b7d1fd99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  background: {fileID: 962975832}
+--- !u!114 &476612527
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476612518}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e1820dfa5ae504a0890dea928ddaf9c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  buttons:
+  - button: {fileID: 760095030}
+    rectTransform: {fileID: 760095028}
 --- !u!1 &612994320
 GameObject:
   m_ObjectHideFlags: 0
@@ -728,7 +768,31 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 760095031}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 476612526}
+        m_TargetAssemblyTypeName: ButtonColorTest, Assembly-CSharp
+        m_MethodName: OnButtonClicked
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 476612523}
+        m_TargetAssemblyTypeName: LtvHudController, Assembly-CSharp
+        m_MethodName: OnCheckmarkClicked
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &760095031
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -767,6 +831,52 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 760095027}
   m_CullTransparentMesh: 1
+--- !u!1 &777000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 777000002}
+  - component: {fileID: 777000003}
+  m_Layer: 0
+  m_Name: XR Interaction Manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &777000002
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 777000001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &777000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 777000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83e4e6cca11330d4088d729ab4fc9d9f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_StartingHoverFilters: []
+  m_StartingSelectFilters: []
 --- !u!1 &808824952
 GameObject:
   m_ObjectHideFlags: 0
@@ -777,7 +887,7 @@ GameObject:
   m_Component:
   - component: {fileID: 808824955}
   - component: {fileID: 808824954}
-  - component: {fileID: 808824953}
+  - component: {fileID: 808824956}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -785,26 +895,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &808824953
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 808824952}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SendPointerHoverToParent: 1
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!114 &808824954
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -835,6 +925,46 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &808824956
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808824952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ab68ce6587aab0146b8dabefbd806791, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_ClickSpeed: 0.3
+  m_MoveDeadzone: 0.6
+  m_RepeatDelay: 0.5
+  m_RepeatRate: 0.1
+  m_TrackedDeviceDragThresholdMultiplier: 2
+  m_TrackedScrollDeltaMultiplier: 5
+  m_BypassUIToolkitEvents: 0
+  m_ActiveInputMode: 1
+  m_MaxTrackedDeviceRaycastDistance: 1000
+  m_EnableXRInput: 1
+  m_EnableMouseInput: 1
+  m_EnableTouchInput: 1
+  m_PointAction: {fileID: 2869410428622933342, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_LeftClickAction: {fileID: 1855836014308820768, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_MiddleClickAction: {fileID: -6289560987278519447, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_RightClickAction: {fileID: -2562941478296515153, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_ScrollWheelAction: {fileID: 5825226938762934180, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_NavigateAction: {fileID: -7967456002180160679, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_SubmitAction: {fileID: 3994978066732806534, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_CancelAction: {fileID: 2387711382375263438, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  m_EnableBuiltinActionsAsFallback: 1
+  m_EnableGamepadInput: 1
+  m_EnableJoystickInput: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
 --- !u!1 &962975830
 GameObject:
   m_ObjectHideFlags: 0
@@ -890,7 +1020,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.6627451, g: 0.8509804, b: 0.8980392, a: 0.78431374}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -1027,6 +1157,7 @@ GameObject:
   - component: {fileID: 1773227991}
   - component: {fileID: 1773227990}
   - component: {fileID: 1773227993}
+  - component: {fileID: 1773227994}
   m_Layer: 0
   m_Name: LtvServices
   m_TagString: Untagged
@@ -1064,11 +1195,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7cef459282e34521ad977df6b05ec21, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  tssApi: {fileID: 0}
-  verificationPollSeconds: 1
-  verificationTimeoutSeconds: 10
-  maxRetries: 3
-  enableDebugLogs: 1
 --- !u!4 &1773227992
 Transform:
   m_ObjectHideFlags: 0
@@ -1096,8 +1222,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c7a2fe0f5f4344849e9ddafdf64033a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  dummyJsonFile: {fileID: 4900000, guid: bcb2a54f942ef4002890e87d46604137, type: 3}
-  queueService: {fileID: 1773227991}
+--- !u!114 &1773227994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1773227989}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4c3b5324139545379ccc7bd728544b33, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tssApi: {fileID: 0}
+  verificationPollSeconds: 1
+  verificationTimeoutSeconds: 10
+  maxRetries: 3
+  enableDebugLogs: 1
 --- !u!1001 &1822070907
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1152,10 +1293,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 7925858141088025043, guid: 2ad7d02c3ee2a447abc9de300646685d, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 476612519}
+    m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2ad7d02c3ee2a447abc9de300646685d, type: 3}
 --- !u!4 &1822070908 stripped
@@ -1273,3 +1411,5 @@ SceneRoots:
   - {fileID: 1822070907}
   - {fileID: 808824955}
   - {fileID: 1773227992}
+  - {fileID: 476612519}
+  - {fileID: 777000002}

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -16,11 +16,12 @@
       }
     },
     "com.unity.burst": {
-      "version": "1.8.9",
+      "version": "1.8.21",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.mathematics": "1.2.1"
+        "com.unity.mathematics": "1.2.1",
+        "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -62,17 +63,17 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
-        "com.unity.ide.visualstudio": "2.0.18",
-        "com.unity.ide.rider": "3.0.24",
+        "com.unity.ide.visualstudio": "2.0.22",
+        "com.unity.ide.rider": "3.0.36",
         "com.unity.ide.vscode": "1.2.5",
         "com.unity.editorcoroutines": "1.0.0",
-        "com.unity.performance.profile-analyzer": "1.2.2",
+        "com.unity.performance.profile-analyzer": "1.2.3",
         "com.unity.test-framework": "1.1.33",
-        "com.unity.testtools.codecoverage": "1.2.4"
+        "com.unity.testtools.codecoverage": "1.2.6"
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.24",
+      "version": "3.0.36",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -81,7 +82,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.18",
+      "version": "2.0.22",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -97,7 +98,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.inputsystem": {
-      "version": "1.8.2",
+      "version": "1.14.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -120,14 +121,14 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.performance.profile-analyzer": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "14.0.8",
+      "version": "14.0.12",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
@@ -145,7 +146,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.settings-manager": {
-      "version": "2.0.1",
+      "version": "2.1.0",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
@@ -156,7 +157,7 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "14.0.8",
+        "com.unity.render-pipelines.core": "14.0.12",
         "com.unity.searcher": "4.9.2"
       }
     },
@@ -182,7 +183,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.testtools.codecoverage": {
-      "version": "1.2.4",
+      "version": "1.2.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -232,7 +233,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.arfoundation": {
-      "version": "5.1.0",
+      "version": "5.2.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -250,7 +251,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.core-utils": {
-      "version": "2.3.0",
+      "version": "2.5.2",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -272,16 +273,16 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.interaction.toolkit": {
-      "version": "2.4.1",
+      "version": "2.6.4",
       "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.ugui": "1.0.0",
-        "com.unity.inputsystem": "1.5.0",
+        "com.unity.inputsystem": "1.7.0",
         "com.unity.mathematics": "1.2.6",
         "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
-        "com.unity.xr.core-utils": "2.2.1",
+        "com.unity.xr.core-utils": "2.2.3",
         "com.unity.modules.physics": "1.0.0",
         "com.unity.xr.legacyinputhelpers": "2.1.10"
       },
@@ -297,7 +298,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.legacyinputhelpers": {
-      "version": "2.1.11",
+      "version": "2.1.12",
       "depth": 1,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Fix `LtvHudController` to use `LtvInstructionService` (replaces deleted `LtvErrorQueueService`) and expose `OnCheckmarkClicked` as a public method for the persistent Inspector listener
- Update `LTV-HUD.unity` scene: replace `InputSystemUIInputModule` with XRITK's `XRUIInputModule`, add `XRInteractionManager`, and fix the Button's persistent onClick to target the correct scene component
- Add `ControllerButtonInteraction.cs` — direct XR input fallback that reads `triggerButton`/`primaryButton` from all XR devices and raycasts against registered button RectTransforms
- Add `ButtonColorTest.cs` — debug script to verify button click (Space bar in Editor, persistent listener on device)
- Add `DummyLtvErrors.json` for development/testing
- Update `Packages/packages-lock.json`