### PR TITLE
feat: add criticality colors and NL descriptions to LTV HUD badge

### DIFF
--- a/Assets/LTV/LtvHudColorTest.cs
+++ b/Assets/LTV/LtvHudColorTest.cs
@@ -1,0 +1,92 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+/// <summary>
+/// Test script: finds the existing "AG NAV" text in the scene and
+/// replaces it with cycling NL descriptions + criticality colors.
+/// Everything else in the HUD stays the same.
+/// </summary>
+public class LtvHudColorTest : MonoBehaviour
+{
+    private static readonly Color ColorCritical = new Color32(229, 57, 53, 220);
+    private static readonly Color ColorHigh     = new Color32(251, 140, 0, 220);
+    private static readonly Color ColorMedium   = new Color32(253, 216, 53, 220);
+    private static readonly Color ColorLow      = new Color32(67, 160, 71, 220);
+
+    private struct TestError
+    {
+        public string code;
+        public string description;
+        public int criticality;
+        public Color color;
+    }
+
+    private List<TestError> testErrors;
+    private TextMeshProUGUI agNavText;
+    private Image agNavBackground;
+    private int currentIndex = 0;
+
+    private void Start()
+    {
+        testErrors = new List<TestError>
+        {
+            new TestError { code = "4761", description = "Dust Sensor",    criticality = 4, color = ColorCritical },
+            new TestError { code = "4155", description = "Power Dist",     criticality = 4, color = ColorCritical },
+            new TestError { code = "3700", description = "Heater Reset",   criticality = 3, color = ColorHigh },
+            new TestError { code = "2900", description = "Power Bus",      criticality = 2, color = ColorMedium },
+            new TestError { code = "2132", description = "Comm Link",      criticality = 2, color = ColorMedium },
+            new TestError { code = "2131", description = "LiDAR",          criticality = 2, color = ColorMedium },
+            new TestError { code = "2130", description = "NAV Restart",    criticality = 2, color = ColorMedium },
+            new TestError { code = "2129", description = "Blown Fuse",     criticality = 2, color = ColorMedium },
+            new TestError { code = "0000", description = "Recovery",       criticality = 0, color = ColorLow },
+        };
+
+        // Find the AG NAV text in the scene
+        TextMeshProUGUI[] allTexts = FindObjectsOfType<TextMeshProUGUI>(true);
+        foreach (TextMeshProUGUI tmp in allTexts)
+        {
+            if (tmp.text.Contains("AG NAV"))
+            {
+                agNavText = tmp;
+                // Get the Image component on the parent (the background box)
+                agNavBackground = tmp.GetComponentInParent<Image>();
+                Debug.Log("[ColorTest] Found AG NAV text, will replace with NL descriptions.");
+                break;
+            }
+        }
+
+        if (agNavText == null)
+        {
+            Debug.LogWarning("[ColorTest] Could not find AG NAV text in scene.");
+            return;
+        }
+
+        StartCoroutine(CycleErrors());
+    }
+
+    private IEnumerator CycleErrors()
+    {
+        while (true)
+        {
+            TestError err = testErrors[currentIndex];
+
+            // Change text, shrink to fit, single line
+            agNavText.text = err.description;
+            agNavText.enableAutoSizing = true;
+            agNavText.fontSizeMin = 8;
+            agNavText.fontSizeMax = 30;
+            agNavText.enableWordWrapping = false;
+            agNavText.overflowMode = TextOverflowModes.Ellipsis;
+
+            if (agNavBackground != null)
+                agNavBackground.color = err.color;
+
+            currentIndex = (currentIndex + 1) % testErrors.Count;
+
+            yield return new WaitForSeconds(2f);
+        }
+    }
+}

--- a/Assets/LTV/LtvHudController.cs
+++ b/Assets/LTV/LtvHudController.cs
@@ -1,85 +1,230 @@
+using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
-using TMPro; // Required for TextMeshPro UI
+using TMPro;
 using LtvDiagnostics;
 
 public class LtvHudController : MonoBehaviour
 {
-    [Header("Backend Service")]
-    public LtvErrorQueueService queueService;
+    [Header("Backend Service (auto-finds if empty)")]
+    public LtvInstructionService instructionService;
 
-    [Header("UI Elements")]
-    public TextMeshProUGUI errorCodeText;   // The left box (formerly "AG NAV")
-    public TextMeshProUGUI instructionText; // The middle instructional text
-    public Button checkmarkButton;          // The right side button
+    // Auto-discovered UI elements from the existing scene
+    private TextMeshProUGUI errorCodeText;   // The AG NAV text
+    private Image errorCodeBackground;        // The AG NAV background image
+    private TextMeshProUGUI instructionText;  // The instruction text
+    private Button checkmarkButton;           // The checkmark button
+
+    // Criticality colors
+    private static readonly Color ColorCritical = new Color32(229, 57, 53, 220);
+    private static readonly Color ColorHigh     = new Color32(251, 140, 0, 220);
+    private static readonly Color ColorMedium   = new Color32(253, 216, 53, 220);
+    private static readonly Color ColorLow      = new Color32(67, 160, 71, 220);
+
+    // Original color so we can restore if needed
+    private Color originalBadgeColor;
+
+    // Natural-language short descriptions for known error codes
+    private static readonly Dictionary<string, string> ShortDescriptions = new Dictionary<string, string>
+    {
+        {"0000", "Recovery"},
+        {"2129", "Blown Fuse"},
+        {"2130", "NAV Restart"},
+        {"2131", "LiDAR"},
+        {"2132", "Comm Link"},
+        {"2900", "Power Bus"},
+        {"3700", "Heater Reset"},
+        {"4155", "Power Dist"},
+        {"4761", "Dust Sensor"},
+    };
+
+    private void Awake()
+    {
+        // Auto-find the instruction service if not assigned
+        if (instructionService == null)
+            instructionService = FindObjectOfType<LtvInstructionService>();
+
+        // Auto-find UI elements by searching the scene
+        FindExistingUiElements();
+    }
+
+    private void FindExistingUiElements()
+    {
+        TextMeshProUGUI[] allTexts = FindObjectsOfType<TextMeshProUGUI>(true);
+
+        foreach (TextMeshProUGUI tmp in allTexts)
+        {
+            // Find the AG NAV text (the error code display)
+            if (tmp.text.Contains("AG NAV") || tmp.text.Contains("ag nav"))
+            {
+                errorCodeText = tmp;
+                errorCodeBackground = tmp.GetComponentInParent<Image>();
+                if (errorCodeBackground != null)
+                    originalBadgeColor = errorCodeBackground.color;
+
+                // Set up auto-sizing so text fits the box
+                tmp.enableAutoSizing = true;
+                tmp.fontSizeMin = 8;
+                tmp.fontSizeMax = 30;
+                tmp.enableWordWrapping = false;
+                tmp.overflowMode = TextOverflowModes.Ellipsis;
+
+                Debug.Log("[LtvHud] Found error code text (AG NAV).");
+            }
+        }
+
+        // Find the instruction text (the longest text element with a procedure-like string)
+        foreach (TextMeshProUGUI tmp in allTexts)
+        {
+            if (tmp != errorCodeText && tmp.text.Contains("Locate"))
+            {
+                instructionText = tmp;
+                Debug.Log("[LtvHud] Found instruction text.");
+                break;
+            }
+        }
+
+        // If we didn't find instruction text by content, try finding it by length
+        if (instructionText == null)
+        {
+            foreach (TextMeshProUGUI tmp in allTexts)
+            {
+                if (tmp != errorCodeText && tmp.text.Length > 20)
+                {
+                    instructionText = tmp;
+                    Debug.Log("[LtvHud] Found instruction text (by length).");
+                    break;
+                }
+            }
+        }
+
+        // Find the checkmark button
+        Button[] allButtons = FindObjectsOfType<Button>(true);
+        foreach (Button btn in allButtons)
+        {
+            // Look for a button with a checkmark image or that's near our UI
+            Image btnImage = btn.GetComponent<Image>();
+            if (btnImage != null)
+            {
+                checkmarkButton = btn;
+                Debug.Log("[LtvHud] Found checkmark button.");
+                break;
+            }
+        }
+    }
 
     private void OnEnable()
     {
-        if (queueService != null)
-        {
-            // Subscribe to the backend events
-            queueService.StepChanged += OnStepChanged;
-            queueService.ErrorChanged += OnErrorChanged;
-            queueService.AllErrorsResolved += OnAllResolved;
-            
-            // Listen for button clicks
+        if (instructionService == null) return;
+
+        instructionService.ErrorChanged       += OnErrorChanged;
+        instructionService.StepChanged        += OnStepChanged;
+        instructionService.AllErrorsResolved  += OnAllResolved;
+        instructionService.ResolutionFailed   += OnResolutionFailed;
+        instructionService.MaxRetriesExceeded += OnMaxRetriesExceeded;
+
+        if (checkmarkButton != null)
             checkmarkButton.onClick.AddListener(OnCheckmarkClicked);
-        }
     }
 
     private void OnDisable()
     {
-        if (queueService != null)
-        {
-            // Unsubscribe to prevent memory leaks
-            queueService.StepChanged -= OnStepChanged;
-            queueService.ErrorChanged -= OnErrorChanged;
-            queueService.AllErrorsResolved -= OnAllResolved;
-            
+        if (instructionService == null) return;
+
+        instructionService.ErrorChanged       -= OnErrorChanged;
+        instructionService.StepChanged        -= OnStepChanged;
+        instructionService.AllErrorsResolved  -= OnAllResolved;
+        instructionService.ResolutionFailed   -= OnResolutionFailed;
+        instructionService.MaxRetriesExceeded -= OnMaxRetriesExceeded;
+
+        if (checkmarkButton != null)
             checkmarkButton.onClick.RemoveListener(OnCheckmarkClicked);
-        }
     }
 
     private void Start()
     {
-        // Kick off the diagnosis when the scene starts 
-        // (You can move this to a voice command later if needed!)
-        if (queueService != null && !queueService.IsDiagnosisActive)
-        {
-            queueService.StartDiagnosisFromTss();
-        }
+        if (instructionService != null && !instructionService.IsDiagnosisActive)
+            instructionService.StartDiagnosisFromTss();
     }
 
-    // 3. When the right-hand button is clicked...
-    private void OnCheckmarkClicked()
-    {
-        // Only advance if a diagnosis is active and we aren't waiting on TSS verification
-        if (queueService != null && queueService.IsDiagnosisActive && !queueService.IsVerifying)
-        {
-            queueService.AdvanceStep();
-        }
-    }
+    // ── Event handlers ──────────────────────────────────────────
 
-    // 1 & 4. Displays the error code (and updates when the next error starts)
     private void OnErrorChanged(LtvError error)
     {
-        errorCodeText.text = error.Code;
+        Color color = GetCriticalityColor(error.Criticality);
+        string desc = GetShortDescription(error);
+
+        // Update the AG NAV box: text + background color
+        if (errorCodeText != null)
+            errorCodeText.text = desc;
+
+        if (errorCodeBackground != null)
+            errorCodeBackground.color = color;
     }
 
-    // 2. Displays the current instruction
     private void OnStepChanged(LtvError error, int stepIndex)
     {
-        instructionText.text = error.Procedures[stepIndex];
+        int total = error.Procedures.Count;
+        string instruction = error.Procedures[stepIndex];
 
-        // Disable the button temporarily if the system is verifying the fix via TSS
-        checkmarkButton.interactable = !queueService.IsVerifying;
+        if (instructionText != null)
+            instructionText.text = $"{stepIndex + 1}. {instruction}";
+
+        if (checkmarkButton != null)
+            checkmarkButton.interactable = !instructionService.IsVerifying;
     }
 
-    // Handles the end-state when everything is fixed
+    private void OnResolutionFailed(LtvError error)
+    {
+        if (instructionText != null)
+        {
+            int retries = instructionService.RetryCount;
+            instructionText.text = $"Verification failed - retrying ({retries}/3)";
+        }
+    }
+
+    private void OnMaxRetriesExceeded(LtvError error)
+    {
+        if (instructionText != null)
+            instructionText.text = "Max retries exceeded - skipping error";
+    }
+
     private void OnAllResolved()
     {
-        errorCodeText.text = "DONE";
-        instructionText.text = "All LTV errors resolved. Systems nominal.";
-        checkmarkButton.interactable = false; // Disable button since we are done
+        if (errorCodeText != null)
+            errorCodeText.text = "ALL OK";
+
+        if (errorCodeBackground != null)
+            errorCodeBackground.color = ColorLow;
+
+        if (instructionText != null)
+            instructionText.text = "All LTV errors resolved. Systems nominal.";
+
+        if (checkmarkButton != null)
+            checkmarkButton.interactable = false;
+    }
+
+    private void OnCheckmarkClicked()
+    {
+        if (instructionService != null && instructionService.IsDiagnosisActive && !instructionService.IsVerifying)
+            instructionService.AdvanceStep();
+    }
+
+    // ── Utilities ───────────────────────────────────────────────
+
+    private static Color GetCriticalityColor(int criticality)
+    {
+        if (criticality >= 4) return ColorCritical;
+        if (criticality == 3) return ColorHigh;
+        if (criticality == 2) return ColorMedium;
+        return ColorLow;
+    }
+
+    private static string GetShortDescription(LtvError error)
+    {
+        if (ShortDescriptions.TryGetValue(error.Code, out string desc))
+            return desc;
+        return string.IsNullOrEmpty(error.Description) ? error.Code : error.Description;
     }
 }


### PR DESCRIPTION
The error code badge now changes color based on error criticality (Red/Orange/Yellow/Green) and displays short natural language descriptions instead of raw error codes. Auto-discovers UI elements at runtime so no Inspector wiring is needed. Includes a visual test script (LtvHudColorTest) for demo purposes.