### PR TITLE
switch Magic Leap SDK to npm scoped registry

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,15 @@
 {
+  "scopedRegistries": [
+    {
+      "name": "Magic Leap",
+      "url": "https://registry.npmjs.org",
+      "scopes": [
+        "com.magicleap"
+      ]
+    }
+  ],
   "dependencies": {
-    "com.magicleap.unitysdk": "file:/Users/tu15/MagicLeap/tools/unity/v2.6.0/com.magicleap.unitysdk.tgz",
+    "com.magicleap.unitysdk": "2.6.0",
     "com.unity.collab-proxy": "2.11.3",
     "com.unity.feature.development": "1.0.1",
     "com.unity.shadergraph": "14.0.8",


### PR DESCRIPTION
Currently `Packages/manifest.json` points `com.magicleap.unitysdk` at a
hardcoded local tarball path — `file:/Users/tu15/MagicLeap/tools/unity/v2.6.0/...`.
On every machine the `tu15` segment (the folder between `/Users/` and
`/MagicLeap/`) has to be manually swapped to match the local username
before Unity can open the project, otherwise package resolution fails
and every XR package breaks with a cascade of CS0234 / CS0246 errors.

This PR switches to Magic Leap's official npm scoped registry
(`registry.npmjs.org`, scope `com.magicleap`) and pins the SDK to
`2.6.0` — same version as the old tarball. Unity pulls it from npm
directly, so no manual path edits are needed anymore.

Only `Packages/manifest.json` is touched.