### PR TITLE
feat(LTV): voice-triggered repair flow with MLVoice + LunaTtsBridge

### DIFF
--- a/Assets/AIA/AIAVoskInputController.cs
+++ b/Assets/AIA/AIAVoskInputController.cs
@@ -166,6 +166,9 @@ public class AIAVoskInputController : MonoBehaviour
     private bool isVoskInitializing;
     private bool isVoskInitialized;
     private bool isRecording;
+    // Set true once a partial transcript routes the LTV-repair command this session,
+    // so subsequent partials don't double-trigger before recording stops.
+    private bool _routedLtvRepairThisSession;
     private Coroutine initializationTimeoutCoroutine;
 
     private void Awake()
@@ -439,6 +442,8 @@ public class AIAVoskInputController : MonoBehaviour
 
         try
         {
+            _routedLtvRepairThisSession = false;
+
             if (voiceIntents != null)
             {
                 voiceIntents.BeginRecordingTranscript();
@@ -584,6 +589,18 @@ public class AIAVoskInputController : MonoBehaviour
             if (voiceIntents != null)
             {
                 voiceIntents.UpdateRecordingTranscript(partialTranscript);
+
+                // VoiceProcessor's silence detection on ML2 doesn't reliably fire, so the
+                // recording stays open and the final transcript never emits. Route LTV-repair
+                // off the live partial stream instead — fires the moment Vosk has heard
+                // enough audio to recognize the command.
+                if (!_routedLtvRepairThisSession &&
+                    voiceIntents.TryRouteLtvRepairCommand(partialTranscript))
+                {
+                    _routedLtvRepairThisSession = true;
+                    Debug.Log($"[Vosk] LTV-repair routed from partial transcript: '{partialTranscript}'. Stopping recording.");
+                    StopRecording();
+                }
             }
             else
             {

--- a/Assets/AIA/LunaTtsBridge.cs
+++ b/Assets/AIA/LunaTtsBridge.cs
@@ -1,0 +1,225 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Persistent (DontDestroyOnLoad) Android TextToSpeech wrapper. Lets any scene
+/// speak through the same voice without each scene re-initializing the engine.
+///
+/// Place ONE instance in the bootstrap/Mission scene. VoiceIntents and any other
+/// caller can fetch it via <see cref="Instance"/> and call <see cref="Speak"/>.
+/// On non-Android platforms (e.g. Editor Play Mode on macOS) Speak is a no-op
+/// that just logs the text, so flow logic still runs.
+/// </summary>
+public class LunaTtsBridge : MonoBehaviour
+{
+    public static LunaTtsBridge Instance { get; private set; }
+
+    [Tooltip("Log every Speak() call so the editor can show the spoken text in the Console.")]
+    public bool logSpokenText = true;
+
+    private AndroidJavaObject _textToSpeech;
+    private AndroidJavaObject _unityActivity;
+    private volatile bool _ready;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+        InitializeTextToSpeech();
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+
+        DisposeTextToSpeech();
+    }
+
+    public void Speak(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        string normalized = NormalizeForSpeech(text);
+
+        if (logSpokenText)
+        {
+            Debug.Log($"[LunaTts] Speak: {normalized}");
+        }
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+        if (!_ready || _textToSpeech == null)
+        {
+            Debug.LogWarning("[LunaTts] Speak called before TTS is ready; skipping.");
+            return;
+        }
+
+        try
+        {
+            Action speakAction = () =>
+            {
+                try
+                {
+                    using (var ttsClass = new AndroidJavaClass("android.speech.tts.TextToSpeech"))
+                    {
+                        int queueFlush = ttsClass.GetStatic<int>("QUEUE_FLUSH");
+                        int errorCode = ttsClass.GetStatic<int>("ERROR");
+                        int result = _textToSpeech.Call<int>(
+                            "speak",
+                            normalized,
+                            queueFlush,
+                            null,
+                            $"luna-tts-{Time.frameCount}");
+
+                        if (result == errorCode)
+                        {
+                            Debug.LogWarning("[LunaTts] Android TextToSpeech.speak() returned ERROR.");
+                        }
+                    }
+                }
+                catch (Exception innerEx)
+                {
+                    Debug.LogWarning($"[LunaTts] speak() failed on UI thread: {innerEx.Message}");
+                }
+            };
+
+            if (_unityActivity != null)
+            {
+                _unityActivity.Call("runOnUiThread", new AndroidJavaRunnable(() => speakAction()));
+            }
+            else
+            {
+                speakAction();
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"[LunaTts] Speak failed: {ex.Message}");
+        }
+#endif
+    }
+
+    private void InitializeTextToSpeech()
+    {
+#if UNITY_ANDROID && !UNITY_EDITOR
+        try
+        {
+            using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+            {
+                _unityActivity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
+                _textToSpeech = new AndroidJavaObject(
+                    "android.speech.tts.TextToSpeech",
+                    _unityActivity,
+                    new TtsInitListener(this));
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"[LunaTts] init failed: {ex.Message}");
+        }
+#endif
+    }
+
+    private void OnTtsInitialized(int status)
+    {
+#if UNITY_ANDROID && !UNITY_EDITOR
+        try
+        {
+            using (var ttsClass = new AndroidJavaClass("android.speech.tts.TextToSpeech"))
+            {
+                int success = ttsClass.GetStatic<int>("SUCCESS");
+                if (status != success || _textToSpeech == null)
+                {
+                    Debug.LogWarning($"[LunaTts] Init status={status} (not SUCCESS).");
+                    _ready = false;
+                    return;
+                }
+            }
+
+            using (var localeClass = new AndroidJavaClass("java.util.Locale"))
+            using (var ttsClass = new AndroidJavaClass("android.speech.tts.TextToSpeech"))
+            {
+                AndroidJavaObject locale = localeClass.GetStatic<AndroidJavaObject>("US");
+                int langResult = _textToSpeech.Call<int>("setLanguage", locale);
+                int langMissingData = ttsClass.GetStatic<int>("LANG_MISSING_DATA");
+                int langNotSupported = ttsClass.GetStatic<int>("LANG_NOT_SUPPORTED");
+                if (langResult == langMissingData || langResult == langNotSupported)
+                {
+                    Debug.LogWarning("[LunaTts] US locale missing or not supported.");
+                }
+            }
+
+            _ready = true;
+            Debug.Log("[LunaTts] Ready.");
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"[LunaTts] init callback error: {ex.Message}");
+            _ready = false;
+        }
+#endif
+    }
+
+    private void DisposeTextToSpeech()
+    {
+#if UNITY_ANDROID && !UNITY_EDITOR
+        if (_textToSpeech == null)
+        {
+            return;
+        }
+
+        try
+        {
+            _textToSpeech.Call("stop");
+            _textToSpeech.Call("shutdown");
+            _textToSpeech.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"[LunaTts] shutdown failed: {ex.Message}");
+        }
+
+        _textToSpeech = null;
+        _unityActivity = null;
+        _ready = false;
+#endif
+    }
+
+    private static string NormalizeForSpeech(string text)
+    {
+        string normalized = text.Replace("\r", " ").Replace("\n", " ").Replace("\t", " ").Trim();
+        while (normalized.Contains("  "))
+        {
+            normalized = normalized.Replace("  ", " ");
+        }
+
+        return normalized;
+    }
+
+    private class TtsInitListener : AndroidJavaProxy
+    {
+        private readonly LunaTtsBridge _owner;
+
+        public TtsInitListener(LunaTtsBridge owner)
+            : base("android.speech.tts.TextToSpeech$OnInitListener")
+        {
+            _owner = owner;
+        }
+
+        public void onInit(int status)
+        {
+            _owner.OnTtsInitialized(status);
+        }
+    }
+}

--- a/Assets/AIA/LunaTtsBridge.cs.meta
+++ b/Assets/AIA/LunaTtsBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ded4bc3dabc04449a056109cffa72db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AIA/MLVoiceIntentsConfiguration.asset
+++ b/Assets/AIA/MLVoiceIntentsConfiguration.asset
@@ -24,6 +24,12 @@ MonoBehaviour:
     Value: stop
   - Id: 105
     Value: hey luna
+  - Id: 106
+    Value: ltv repair
+  - Id: 107
+    Value: start ltv repair
+  - Id: 108
+    Value: begin ltv repair
   AutoAllowAllSystemIntents: 0
   SystemCommands: 0
   SlotsForVoiceCommands: []

--- a/Assets/AIA/VoiceIntents.cs
+++ b/Assets/AIA/VoiceIntents.cs
@@ -11,6 +11,10 @@ using UnityEngine.XR.MagicLeap;
 public class VoiceIntents : MonoBehaviour
 {
     private const uint AskLunaEventId = 105;
+    // MLVoice intent IDs that route directly to LTV-repair (bypasses Vosk).
+    // Configured in Assets/AIA/MLVoiceIntentsConfiguration.asset.
+    private const uint LtvRepairEventIdMin = 106;
+    private const uint LtvRepairEventIdMax = 108;
     private const int AiRequestTimeoutSeconds = 30;
     private const string OllamaIpEnvironmentVariable = "LUNA_OLLAMA_IP";
     private const int MaxVisibleConversationTurns = 3;
@@ -33,6 +37,11 @@ public class VoiceIntents : MonoBehaviour
     [SerializeField] private Text responseTextBox;
     [SerializeField] private AIAVoskInputController aiaInputController;
     [SerializeField] private ScrollRect responseScrollRect;
+
+    [Header("Voice command routing")]
+    [Tooltip("Optional LTV-repair voice coordinator. If present and the transcript matches its " +
+             "trigger phrases, the prompt is consumed locally instead of being forwarded to Gemma.")]
+    [SerializeField] private LtvVoiceCoordinator ltvVoiceCoordinator;
 
     [Header("Debugging")]
     [SerializeField] private bool verboseVoiceLogging = true;
@@ -94,7 +103,18 @@ public class VoiceIntents : MonoBehaviour
         TryResolveResponseScrollRect();
         TryResolveAiaInputController();
         MLPermissions.RequestPermission(MLPermission.VoiceInput, permissionCallbacks);
-        InitializeTextToSpeech();
+
+        // Prefer LunaTtsBridge (persistent, scene-spanning) when one exists in the scene.
+        // Only initialize the inline Android TTS if no bridge is wired up — this avoids
+        // two TextToSpeech engines competing for the audio service on ML2.
+        if (FindObjectOfType<LunaTtsBridge>() == null)
+        {
+            InitializeTextToSpeech();
+        }
+        else
+        {
+            Debug.Log("[Luna] LunaTtsBridge present; routing TTS through it instead of inline engine.");
+        }
 
         if (responseTextBox != null && string.IsNullOrWhiteSpace(responseTextBox.text))
         {
@@ -264,7 +284,21 @@ public class VoiceIntents : MonoBehaviour
                 break;
 
             default:
-                Debug.Log($"Unhandled voice intent event id: {voiceEvent.EventID}");
+                if (voiceEvent.EventID >= LtvRepairEventIdMin && voiceEvent.EventID <= LtvRepairEventIdMax)
+                {
+                    Debug.Log($"[Luna] LTV-repair MLVoice intent fired (id={voiceEvent.EventID}, name='{voiceEvent.EventName}')");
+                    string spokenPhrase = string.IsNullOrWhiteSpace(voiceEvent.EventName)
+                        ? "ltv repair"
+                        : voiceEvent.EventName;
+                    if (!TryRouteLtvRepairCommand(spokenPhrase))
+                    {
+                        Debug.LogWarning("[Luna] LTV-repair MLVoice intent matched but coordinator did not accept it.");
+                    }
+                }
+                else
+                {
+                    Debug.Log($"Unhandled voice intent event id: {voiceEvent.EventID}");
+                }
                 break;
         }
     }
@@ -322,6 +356,26 @@ public class VoiceIntents : MonoBehaviour
         }
 
         aiaInputController = FindObjectOfType<AIAVoskInputController>();
+    }
+
+    /// <summary>
+    /// Public so AIAVoskInputController can fire LTV-repair routing on partial Vosk
+    /// transcripts (without waiting for the recording to stop and a final result to
+    /// emit). Returns true when the transcript matched and the LTV scene was loaded.
+    /// </summary>
+    public bool TryRouteLtvRepairCommand(string trimmedPrompt)
+    {
+        if (ltvVoiceCoordinator == null)
+        {
+            ltvVoiceCoordinator = FindObjectOfType<LtvVoiceCoordinator>();
+        }
+
+        if (ltvVoiceCoordinator == null)
+        {
+            return false;
+        }
+
+        return ltvVoiceCoordinator.TryHandleVoiceCommand(trimmedPrompt);
     }
 
     private void UpdateResponseTextBox(string text)
@@ -411,6 +465,14 @@ public class VoiceIntents : MonoBehaviour
         {
             Debug.LogWarning("[Luna] Ignoring empty text prompt.");
             FailActiveRecording("Luna could not hear a question.");
+            return;
+        }
+
+        if (TryRouteLtvRepairCommand(trimmedPrompt))
+        {
+            // The coordinator will load the LTV scene and run the repair flow.
+            // We intentionally do NOT forward this transcript to Gemma.
+            CompleteActiveConversation("Loading LTV repair console.");
             return;
         }
 
@@ -699,6 +761,14 @@ public class VoiceIntents : MonoBehaviour
     {
         if (!speakAiResponse)
         {
+            return;
+        }
+
+        // Prefer the persistent bridge — it survives scene transitions and is the only TTS
+        // we initialize when present. Inline path below only runs as a fallback.
+        if (LunaTtsBridge.Instance != null)
+        {
+            LunaTtsBridge.Instance.Speak(text);
             return;
         }
 

--- a/Assets/LTV/LtvFlashOverlay.cs
+++ b/Assets/LTV/LtvFlashOverlay.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Fullscreen green flash used to bookend LTV-repair (start + end). At runtime this
+/// spawns a tinted quad parented to the rendering camera, sized to overcover the
+/// camera frustum, so the flash fills the user's view in XR rather than being
+/// constrained to a world-space HUD canvas. Call <see cref="Flash"/> from any caller;
+/// pass an action that runs after the fade completes (used to chain TTS / scene
+/// transitions).
+/// </summary>
+public class LtvFlashOverlay : MonoBehaviour
+{
+    [Tooltip("Color of the flash. Alpha here is ignored; alpha is driven by the curve.")]
+    public Color flashColor = new Color(0.2f, 0.85f, 0.35f, 1f);
+
+    [Tooltip("Total duration in seconds: half is fade-in, half is fade-out.")]
+    public float duration = 1.5f;
+
+    [Tooltip("Peak alpha at the midpoint (0..1).")]
+    [Range(0f, 1f)]
+    public float peakAlpha = 0.5f;
+
+    [Tooltip("Distance from the camera at which the fullscreen quad is placed. " +
+             "Should sit just past the camera's near plane.")]
+    public float quadDistance = 0.3f;
+
+    [Tooltip("Extra coverage margin so the quad over-fills the frustum and never " +
+             "shows a seam at the edges.")]
+    public float coverageMargin = 1.4f;
+
+    private Coroutine _running;
+    private Camera _camera;
+    private Transform _quad;
+    private Material _quadMat;
+    private Texture2D _quadTex;
+
+    private void Awake()
+    {
+        // Legacy: this component used to drive a sibling UI Image on a small
+        // world-space HUD canvas. Hide it so it doesn't show as a tiny green panel.
+        var img = GetComponent<Image>();
+        if (img != null)
+        {
+            var c = img.color;
+            c.a = 0f;
+            img.color = c;
+            img.enabled = false;
+        }
+
+        EnsureQuad();
+    }
+
+    /// <summary>Starts the flash. <paramref name="onComplete"/> runs after the fade ends. Idempotent.</summary>
+    public void Flash(Action onComplete = null)
+    {
+        if (_running != null)
+        {
+            StopCoroutine(_running);
+        }
+
+        _running = StartCoroutine(FlashRoutine(onComplete));
+    }
+
+    private void EnsureQuad()
+    {
+        if (_quad != null) return;
+
+        _camera = Camera.main;
+        if (_camera == null)
+        {
+            var all = Camera.allCameras;
+            if (all != null && all.Length > 0) _camera = all[0];
+        }
+        if (_camera == null)
+        {
+            Debug.LogWarning("[LtvFlashOverlay] No camera found; flash will not be visible.", this);
+            return;
+        }
+
+        var go = GameObject.CreatePrimitive(PrimitiveType.Quad);
+        go.name = "LtvFlashQuad";
+        var col = go.GetComponent<Collider>();
+        if (col != null) Destroy(col);
+
+        // Make the quad render on both sides so we don't have to reason about
+        // which way Unity's Quad primitive faces in this Unity version.
+        var mf = go.GetComponent<MeshFilter>();
+        if (mf != null && mf.sharedMesh != null)
+        {
+            var mesh = Instantiate(mf.sharedMesh);
+            var tris = mesh.triangles;
+            var dbl = new int[tris.Length * 2];
+            Array.Copy(tris, 0, dbl, 0, tris.Length);
+            for (int i = 0; i < tris.Length; i += 3)
+            {
+                dbl[tris.Length + i + 0] = tris[i + 2];
+                dbl[tris.Length + i + 1] = tris[i + 1];
+                dbl[tris.Length + i + 2] = tris[i + 0];
+            }
+            mesh.triangles = dbl;
+            mesh.RecalculateNormals();
+            mesh.RecalculateBounds();
+            mf.sharedMesh = mesh;
+        }
+
+        _quad = go.transform;
+        _quad.SetParent(_camera.transform, false);
+        _quad.localRotation = Quaternion.identity;
+        _quad.localPosition = new Vector3(0f, 0f, Mathf.Max(0.05f, quadDistance));
+
+        SizeQuadToFrustum();
+
+        var renderer = go.GetComponent<Renderer>();
+        Shader sh = Shader.Find("Unlit/Transparent");
+        if (sh == null) sh = Shader.Find("Sprites/Default");
+        if (sh == null) sh = Shader.Find("UI/Default");
+        _quadMat = new Material(sh);
+        _quadMat.renderQueue = 4000; // draw on top of everything
+
+        _quadTex = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+        _quadTex.filterMode = FilterMode.Point;
+        _quadTex.wrapMode = TextureWrapMode.Clamp;
+        _quadMat.mainTexture = _quadTex;
+
+        renderer.sharedMaterial = _quadMat;
+        renderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        renderer.receiveShadows = false;
+
+        SetAlpha(0f);
+    }
+
+    private void SizeQuadToFrustum()
+    {
+        if (_quad == null || _camera == null) return;
+        float d = Mathf.Max(0.05f, quadDistance);
+        float h = 2f * d * Mathf.Tan(_camera.fieldOfView * 0.5f * Mathf.Deg2Rad);
+        float w = h * Mathf.Max(0.01f, _camera.aspect);
+        float m = Mathf.Max(1f, coverageMargin);
+        _quad.localScale = new Vector3(w * m, h * m, 1f);
+    }
+
+    private IEnumerator FlashRoutine(Action onComplete)
+    {
+        EnsureQuad();
+        if (_quad == null || _quadTex == null)
+        {
+            onComplete?.Invoke();
+            _running = null;
+            yield break;
+        }
+
+        // Re-fit each flash in case the camera FOV/aspect changed since Awake.
+        SizeQuadToFrustum();
+
+        float t = 0f;
+        float total = Mathf.Max(0.05f, duration);
+        while (t < total)
+        {
+            t += Time.unscaledDeltaTime;
+            float n = Mathf.Clamp01(t / total);
+            // Triangular envelope: ramp 0->1 in first half, 1->0 in second half.
+            float envelope = n < 0.5f ? n * 2f : (1f - n) * 2f;
+            // Smoothstep so the gradient feels soft rather than linear.
+            float smooth = envelope * envelope * (3f - 2f * envelope);
+            SetAlpha(smooth * peakAlpha);
+            yield return null;
+        }
+
+        SetAlpha(0f);
+        _running = null;
+        onComplete?.Invoke();
+    }
+
+    private void SetAlpha(float a)
+    {
+        if (_quadTex == null) return;
+        Color c = flashColor;
+        c.a = a;
+        _quadTex.SetPixel(0, 0, c);
+        _quadTex.Apply(false);
+        if (_quadMat != null && _quadMat.HasProperty("_Color"))
+        {
+            _quadMat.SetColor("_Color", c);
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (_quadMat != null) Destroy(_quadMat);
+        if (_quadTex != null) Destroy(_quadTex);
+    }
+}

--- a/Assets/LTV/LtvFlashOverlay.cs.meta
+++ b/Assets/LTV/LtvFlashOverlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1f4bf472f5e246e78f328f21b10a4ce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTV/LtvInstructionService.cs
+++ b/Assets/LTV/LtvInstructionService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using LtvDiagnostics;
 using TssApi;
 using UnityEngine;
@@ -29,6 +30,12 @@ public class LtvInstructionService : MonoBehaviour
     public event Action<LtvError> ResolutionFailed;
     public event Action<LtvError> MaxRetriesExceeded;
     public event Action AllErrorsResolved;
+    /// <summary>
+    /// Fired when StartDiagnosisFromTss completes its initial enqueue. The int is the
+    /// number of errors with needs_resolved=true at start; 0 means TSS reported nothing
+    /// to fix (the LTV-repair flow uses this to decide whether to skip the procedure).
+    /// </summary>
+    public event Action<int> DiagnosisStarted;
 
     // Public read-only state
     public LtvError CurrentError => currentError;
@@ -50,14 +57,20 @@ public class LtvInstructionService : MonoBehaviour
 
     private void Awake()
     {
-        if (tssApi == null)
-        {
-            tssApi = GetComponent<TssUnityApiService>();
-        }
-
-        if (tssApi == null)
+        // Prefer the persistent singleton over scene-local references. Reason: when this
+        // service lives in the LTV scene (Mission already has its own TssUnityApiService
+        // marked DontDestroyOnLoad), the LTV scene's local component gets self-destroyed
+        // by the singleton check in TssUnityApiService.Awake. A serialized [SerializeField]
+        // tssApi reference here would still point at that destroyed component — its _ltv
+        // dictionary is empty, so GetLtvErrorProcedures() returns 0 even when the Mission
+        // singleton has fresh data.
+        if (TssUnityApiService.Instance != null)
         {
             tssApi = TssUnityApiService.Instance;
+        }
+        else if (tssApi == null)
+        {
+            tssApi = GetComponent<TssUnityApiService>();
         }
 
         if (tssApi == null)
@@ -68,7 +81,8 @@ public class LtvInstructionService : MonoBehaviour
         if (enableDebugLogs)
         {
             Debug.Log(
-                $"[LTV] Service ready. TssApi linked={tssApi != null}",
+                $"[LTV] Service ready. TssApi linked={tssApi != null}" +
+                (tssApi != null ? $" (instanceId={tssApi.GetInstanceID()}, isSingleton={ReferenceEquals(tssApi, TssUnityApiService.Instance)})" : ""),
                 this
             );
         }
@@ -117,14 +131,38 @@ public class LtvInstructionService : MonoBehaviour
 
         List<Dictionary<string, object>> errorProcedures = tssApi.GetLtvErrorProcedures();
 
+        int rawCount = errorProcedures?.Count ?? 0;
+        int rawNeedsResolved = 0;
+        if (errorProcedures != null)
+        {
+            for (int i = 0; i < errorProcedures.Count; i++)
+            {
+                Dictionary<string, object> raw = errorProcedures[i];
+                if (raw != null && raw.ContainsKey("needs_resolved") && ToBool(raw["needs_resolved"]))
+                {
+                    rawNeedsResolved++;
+                }
+            }
+        }
+
+        if (enableDebugLogs)
+        {
+            Debug.Log(
+                $"[LTV] TSS returned {rawCount} error_procedures entries " +
+                $"(needs_resolved=true on {rawNeedsResolved} of them).",
+                this
+            );
+        }
+
         if (errorProcedures == null || errorProcedures.Count == 0)
         {
             if (enableDebugLogs)
             {
-                Debug.Log("[LTV] No error_procedures returned from TSS.", this);
+                Debug.Log("[LTV] No error_procedures returned from TSS — likely UDP timeout or empty response.", this);
             }
 
             diagnosisActive = false;
+            DiagnosisStarted?.Invoke(0);
             AllErrorsResolved?.Invoke();
             EmitSnapshot();
             return;
@@ -139,8 +177,24 @@ public class LtvInstructionService : MonoBehaviour
             }
 
             LtvError error = ParseError(raw);
-            if (error == null || !error.NeedsResolved)
+            if (error == null)
             {
+                if (enableDebugLogs)
+                {
+                    Debug.Log("[LTV] Skipping error: ParseError returned null.", this);
+                }
+                continue;
+            }
+
+            if (!error.NeedsResolved)
+            {
+                if (enableDebugLogs)
+                {
+                    Debug.Log(
+                        $"[LTV] Skipping error {error.Code} ({error.Description}): needs_resolved=false.",
+                        this
+                    );
+                }
                 continue;
             }
 
@@ -171,10 +225,14 @@ public class LtvInstructionService : MonoBehaviour
             }
         }
 
+        int initialCount = errorHeap.Count;
+
         if (enableDebugLogs)
         {
-            Debug.Log($"[LTV] Diagnosis started. {errorHeap.Count} errors queued.", this);
+            Debug.Log($"[LTV] Diagnosis started. {initialCount} errors queued.", this);
         }
+
+        DiagnosisStarted?.Invoke(initialCount);
 
         PopNextError();
     }
@@ -724,7 +782,111 @@ public class LtvInstructionService : MonoBehaviour
             }
         }
 
+        procedures = NormalizeProcedures(procedures);
+
         return new LtvError(code, description, needsResolved, procedures);
+    }
+
+    /// <summary>
+    /// Some TSS feeds deliver a multi-step procedure as a single concatenated
+    /// string ("1. Do X 2. Do Y 3. Do Z"). The HUD shows one entry of this list
+    /// per click, so without splitting the user sees every step at once. This
+    /// detects sequential "N. " markers and splits the string into individual
+    /// steps. Entries that already arrive as separate items pass through unchanged.
+    /// </summary>
+    private static List<string> NormalizeProcedures(List<string> input)
+    {
+        List<string> output = new List<string>();
+        if (input == null) return output;
+
+        for (int i = 0; i < input.Count; i++)
+        {
+            string raw = input[i];
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                continue;
+            }
+
+            List<string> split = SplitSequentialNumberedSteps(raw);
+            if (split != null && split.Count > 1)
+            {
+                output.AddRange(split);
+            }
+            else
+            {
+                output.Add(raw.Trim());
+            }
+        }
+
+        return output;
+    }
+
+    /// <summary>
+    /// Splits a string on sequential numbered markers ("1.", "2.", "3.", ...) only
+    /// when at least two consecutive numbers in proper sequence are present.
+    /// Returns null when no valid split can be made; the caller falls back to
+    /// keeping the original string as a single step.
+    /// </summary>
+    private static List<string> SplitSequentialNumberedSteps(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return null;
+
+        // Word-boundary + digits + "." + (NOT another digit). Tolerates both
+        // "17. To" and the no-space "17.To" shape that appears in the actual
+        // 4800 feed, while excluding decimal numbers like "17.5".
+        MatchCollection matches = Regex.Matches(text, @"\b(\d+)\.(?!\d)");
+        if (matches.Count < 2) return null;
+
+        // Walk matches and keep only those that form a strictly +1 sequence
+        // starting at 1 or 2 (the first marker may legitimately be "1." or, if
+        // the first step has no leading number, "2.").
+        List<int> startIndices = new List<int>();
+        int prevNum = -1;
+        for (int i = 0; i < matches.Count; i++)
+        {
+            int num;
+            if (!int.TryParse(matches[i].Groups[1].Value, out num)) continue;
+
+            if (startIndices.Count == 0)
+            {
+                if (num != 1 && num != 2) continue;
+            }
+            else if (num != prevNum + 1)
+            {
+                // Number out of sequence — likely a reference inside a step
+                // ("go back to step 1."). Skip without breaking the chain.
+                continue;
+            }
+
+            startIndices.Add(matches[i].Index);
+            prevNum = num;
+        }
+
+        if (startIndices.Count < 2) return null;
+
+        List<string> result = new List<string>();
+
+        // If the first valid marker is "2." (i.e., step 1 had no leading number),
+        // capture the prefix before it as the first step so we don't drop content.
+        int firstNum;
+        int.TryParse(Regex.Match(text.Substring(startIndices[0]), @"^(\d+)\.").Groups[1].Value, out firstNum);
+        if (firstNum == 2 && startIndices[0] > 0)
+        {
+            string prefix = text.Substring(0, startIndices[0]).Trim();
+            if (prefix.Length > 0) result.Add(prefix);
+        }
+
+        for (int i = 0; i < startIndices.Count; i++)
+        {
+            int start = startIndices[i];
+            int end = (i + 1 < startIndices.Count) ? startIndices[i + 1] : text.Length;
+            string segment = text.Substring(start, end - start).Trim();
+            // Normalize "17.To" → "17. To" so the user-facing text reads consistently.
+            segment = Regex.Replace(segment, @"^(\d+)\.(\S)", "$1. $2");
+            if (segment.Length > 0) result.Add(segment);
+        }
+
+        return result;
     }
 
     private static string MapCodeToErrorKey(string code)
@@ -734,17 +896,19 @@ public class LtvInstructionService : MonoBehaviour
             return string.Empty;
         }
 
+        // Codes match the LTV_ERRORS.json schema released by NASA SUITS 2026 (see
+        // documents/updates/updates.pdf, 4/24 entry). The mapping is a best-effort
+        // translation to the keys TSS may expose in GetLtvErrors(); when no mapping
+        // exists the verifier falls back to re-checking needs_resolved on the same code.
         switch (code)
         {
-            case "0000": return "recovery_mode";
-            case "4155": return "power_distribution";
-            case "4761": return "dust_sensor";
-            case "2129": return "fuse";
-            case "2130": return "nav_system";
-            case "2131": return "lidar_system";
-            case "2132": return "comms";
-            case "3700": return "electronic_heater";
-            case "2900": return "power_subsystem_bus";
+            case "4800": return "recovery_mode";
+            case "4509": return "nav_system";
+            case "1969": return "fuse";
+            case "3452": return "comms_rssi";
+            case "4968": return "power_subsystem_bus";
+            case "2441": return "comms_reboot";
+            case "2235": return "dust_sensor";
             default: return string.Empty;
         }
     }

--- a/Assets/LTV/LtvSceneBootstrapper.cs
+++ b/Assets/LTV/LtvSceneBootstrapper.cs
@@ -1,0 +1,191 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Lives in the LTV scene. On Start, if <see cref="LtvVoiceCoordinator.PendingVoiceTrigger"/>
+/// is set (i.e. we got here via the "ltv repair" voice command from Mission), runs the
+/// bookend flow:
+///   1. Green flash overlay.
+///   2. StartDiagnosisFromTss; DiagnosisStarted(count) fires.
+///      - count > 0: speak "Initializing LTV-Repair. Found X issues..." and let the user work.
+///      - count == 0: speak "No LTV issues found, returning to Mission" and auto-return.
+///   3. When AllErrorsResolved fires (and we had real work to do), green flash again,
+///      speak "LTV-repair finished", auto-return to Mission.
+/// </summary>
+public class LtvSceneBootstrapper : MonoBehaviour
+{
+    [Header("Scene wiring")]
+    [Tooltip("LTV repair queue / TSS bridge. Defaults to the first one found in the scene.")]
+    public LtvInstructionService instructionService;
+
+    [Tooltip("Fullscreen green flash overlay. Defaults to the first one found in the scene.")]
+    public LtvFlashOverlay flashOverlay;
+
+    [Header("Return")]
+    [Tooltip("Scene to load after the repair flow ends. Must be in Build Settings.")]
+    public string returnSceneName = "Mission";
+
+    [Tooltip("Seconds to wait after the end-flash + TTS before loading the return scene.")]
+    public float returnDelaySeconds = 3f;
+
+    [Header("Behavior")]
+    [Tooltip("If true, runs the flow even when the voice trigger flag isn't set " +
+             "(useful for editor testing).")]
+    public bool runWithoutVoiceTrigger = false;
+
+    [Tooltip("Log every transition through the bootstrap state machine.")]
+    public bool enableDebugLogs = true;
+
+    private bool _subscribed;
+    private bool _hadInitialErrors;
+    private bool _returnScheduled;
+
+    private void Start()
+    {
+        bool triggered = LtvVoiceCoordinator.PendingVoiceTrigger;
+        LtvVoiceCoordinator.ClearPendingTrigger();
+
+        if (!triggered && !runWithoutVoiceTrigger)
+        {
+            if (enableDebugLogs)
+            {
+                Debug.Log("[LtvBoot] No voice trigger; standing by. (Set runWithoutVoiceTrigger to test in editor.)", this);
+            }
+            return;
+        }
+
+        ResolveSceneRefs();
+
+        if (instructionService == null)
+        {
+            Debug.LogError("[LtvBoot] LtvInstructionService not found in scene; cannot run repair flow.", this);
+            return;
+        }
+
+        SubscribeServiceEvents();
+
+        if (flashOverlay != null)
+        {
+            flashOverlay.Flash();
+        }
+
+        // StartDiagnosisFromTss is synchronous w.r.t. firing DiagnosisStarted.
+        // Calling here means by the time we return, DiagnosisStarted has already
+        // fired and OnDiagnosisStarted has handled the count-based branching.
+        instructionService.StartDiagnosisFromTss();
+    }
+
+    private void OnDestroy()
+    {
+        UnsubscribeServiceEvents();
+    }
+
+    private void ResolveSceneRefs()
+    {
+        if (instructionService == null)
+        {
+            instructionService = FindObjectOfType<LtvInstructionService>();
+        }
+
+        if (flashOverlay == null)
+        {
+            flashOverlay = FindObjectOfType<LtvFlashOverlay>();
+        }
+    }
+
+    private void SubscribeServiceEvents()
+    {
+        if (_subscribed || instructionService == null) return;
+        instructionService.DiagnosisStarted += OnDiagnosisStarted;
+        instructionService.AllErrorsResolved += OnAllErrorsResolved;
+        _subscribed = true;
+    }
+
+    private void UnsubscribeServiceEvents()
+    {
+        if (!_subscribed || instructionService == null) return;
+        instructionService.DiagnosisStarted -= OnDiagnosisStarted;
+        instructionService.AllErrorsResolved -= OnAllErrorsResolved;
+        _subscribed = false;
+    }
+
+    private void OnDiagnosisStarted(int errorCount)
+    {
+        if (enableDebugLogs)
+        {
+            Debug.Log($"[LtvBoot] DiagnosisStarted count={errorCount}", this);
+        }
+
+        if (errorCount <= 0)
+        {
+            _hadInitialErrors = false;
+            Speak("No LTV issues found, returning to Mission.");
+            ScheduleReturnToMission();
+            return;
+        }
+
+        _hadInitialErrors = true;
+        string issueWord = errorCount == 1 ? "issue" : "issues";
+        Speak($"Initializing LTV repair. Found {errorCount} {issueWord}. Please follow the instructions at the top of the screen.");
+    }
+
+    private void OnAllErrorsResolved()
+    {
+        if (enableDebugLogs)
+        {
+            Debug.Log($"[LtvBoot] AllErrorsResolved (hadInitialErrors={_hadInitialErrors})", this);
+        }
+
+        if (!_hadInitialErrors)
+        {
+            // The "0 initial issues" path already scheduled the return; don't double-fire.
+            return;
+        }
+
+        if (flashOverlay != null)
+        {
+            flashOverlay.Flash();
+        }
+
+        Speak("LTV repair finished.");
+        ScheduleReturnToMission();
+    }
+
+    private void ScheduleReturnToMission()
+    {
+        if (_returnScheduled) return;
+        _returnScheduled = true;
+        StartCoroutine(ReturnToMissionAfterDelay());
+    }
+
+    private IEnumerator ReturnToMissionAfterDelay()
+    {
+        yield return new WaitForSeconds(Mathf.Max(0f, returnDelaySeconds));
+
+        if (enableDebugLogs)
+        {
+            Debug.Log($"[LtvBoot] Loading return scene '{returnSceneName}'.", this);
+        }
+
+        if (string.IsNullOrWhiteSpace(returnSceneName))
+        {
+            Debug.LogWarning("[LtvBoot] returnSceneName is empty; staying in LTV scene.", this);
+            yield break;
+        }
+
+        SceneManager.LoadScene(returnSceneName);
+    }
+
+    private void Speak(string text)
+    {
+        if (LunaTtsBridge.Instance != null)
+        {
+            LunaTtsBridge.Instance.Speak(text);
+        }
+        else if (enableDebugLogs)
+        {
+            Debug.LogWarning($"[LtvBoot] LunaTtsBridge.Instance is null; would have spoken: '{text}'", this);
+        }
+    }
+}

--- a/Assets/LTV/LtvSceneBootstrapper.cs.meta
+++ b/Assets/LTV/LtvSceneBootstrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7fe3ef8acdc2405fa139a92ae28824f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LTV/LtvVoiceCoordinator.cs
+++ b/Assets/LTV/LtvVoiceCoordinator.cs
@@ -1,0 +1,81 @@
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Lives in the Mission scene. <see cref="VoiceIntents"/> calls
+/// <see cref="TryHandleVoiceCommand"/> with each transcript before forwarding
+/// to the AI; if the transcript matches the LTV-repair trigger phrase we set
+/// the cross-scene flag and load the LTV scene. The actual flash + TTS + scene
+/// auto-return live in <see cref="LtvSceneBootstrapper"/> so the in-scene
+/// camera and overlay are addressable.
+/// </summary>
+public class LtvVoiceCoordinator : MonoBehaviour
+{
+    /// <summary>Set true when the voice trigger fires; LtvSceneBootstrapper consumes and clears it.</summary>
+    public static bool PendingVoiceTrigger { get; private set; }
+
+    [Tooltip("Scene to load when the LTV-repair voice command fires. Must be in Build Settings.")]
+    public string ltvSceneName = "LTV";
+
+    [Tooltip("Case-insensitive substring(s) that trigger the LTV-repair flow. " +
+             "Whitespace and punctuation are normalized before matching.")]
+    public string[] triggerPhrases = { "ltv repair", "ltv-repair", "lt v repair" };
+
+    [Tooltip("Log every transcript we evaluate, even non-matching ones. Off in flight.")]
+    public bool enableDebugLogs = true;
+
+    /// <summary>
+    /// Returns true if the transcript matched and the LTV scene transition was queued.
+    /// VoiceIntents should suppress the AI request when this returns true.
+    /// </summary>
+    public bool TryHandleVoiceCommand(string transcript)
+    {
+        if (string.IsNullOrWhiteSpace(transcript) || triggerPhrases == null || triggerPhrases.Length == 0)
+        {
+            return false;
+        }
+
+        string normalized = NormalizeForMatch(transcript);
+
+        for (int i = 0; i < triggerPhrases.Length; i++)
+        {
+            string phrase = triggerPhrases[i];
+            if (string.IsNullOrWhiteSpace(phrase)) continue;
+            if (normalized.IndexOf(NormalizeForMatch(phrase), System.StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                continue;
+            }
+
+            if (enableDebugLogs)
+            {
+                Debug.Log($"[LtvVoice] Matched trigger '{phrase}' in transcript '{transcript}'. Loading scene '{ltvSceneName}'.", this);
+            }
+
+            PendingVoiceTrigger = true;
+            LunaTtsBridge.Instance?.Speak("Loading LTV repair console.");
+            SceneManager.LoadScene(ltvSceneName);
+            return true;
+        }
+
+        if (enableDebugLogs)
+        {
+            Debug.Log($"[LtvVoice] No trigger phrase matched. Transcript: '{transcript}' (normalized='{normalized}'). Falling through to AI.", this);
+        }
+
+        return false;
+    }
+
+    /// <summary>Test hook so the LTV-repair flow can be entered without a real voice trigger.</summary>
+    public static void ClearPendingTrigger()
+    {
+        PendingVoiceTrigger = false;
+    }
+
+    private static string NormalizeForMatch(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+        // Lowercase, replace runs of non-letter characters with single spaces.
+        return Regex.Replace(text.ToLowerInvariant(), "[^a-z0-9]+", " ").Trim();
+    }
+}

--- a/Assets/LTV/LtvVoiceCoordinator.cs.meta
+++ b/Assets/LTV/LtvVoiceCoordinator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c12f3bab58fb4de5a7e17fcd66e743f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/final_scenes/LTV.unity
+++ b/Assets/Scenes/final_scenes/LTV.unity
@@ -38,7 +38,6 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028326, g: 0.22571333, b: 0.30692202, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -133,39 +132,39 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 0.0023979554
       objectReference: {fileID: 0}
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.0072259903
       objectReference: {fileID: 0}
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -0.14006145
       objectReference: {fileID: 0}
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.9986357
       objectReference: {fileID: 0}
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: 0.05151278
       objectReference: {fileID: 0}
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0.008548151
       objectReference: {fileID: 0}
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: 0.00044091797
       objectReference: {fileID: 0}
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: 5.906
       objectReference: {fileID: 0}
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: -0.981
       objectReference: {fileID: 0}
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -483,6 +482,75 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 375528243}
   m_CullTransparentMesh: 1
+--- !u!1001 &467610813
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.16
+      objectReference: {fileID: 0}
+    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.272
+      objectReference: {fileID: 0}
+    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 530999540994195327, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 108399580}
+    - target: {fileID: 8715221860109088846, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_Name
+      value: GrabbableVitalsMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 8715221860109088846, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8768581901916219118, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
+      propertyPath: m_PresetInfoIsWorld
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
 --- !u!1 &476612518
 GameObject:
   m_ObjectHideFlags: 0
@@ -518,6 +586,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 962975831}
+  - {fileID: 819285901}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -605,8 +674,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1a2d7d89889b4d94fa1f8d6fe49788e8, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Target: {fileID: 108399581}
   m_TargetOffset: {x: 0, y: 0.3, z: 1.2}
   m_FollowInLocalSpace: 0
@@ -634,7 +703,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 02e29eabfb89d44fb93e6c58b7d1fd99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  background: {fileID: 962975832}
 --- !u!114 &476612528
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -707,8 +775,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreLayout: 0
-  m_MinWidth: 50
-  m_MinHeight: 50
+  m_MinWidth: 140
+  m_MinHeight: 90
   m_PreferredWidth: -1
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
@@ -785,7 +853,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_RaycastPadding: {x: -40, y: -40, z: -40, w: -40}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -808,6 +876,99 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 760095027}
   m_CullTransparentMesh: 1
+--- !u!1 &819285897
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 819285901}
+  - component: {fileID: 819285900}
+  - component: {fileID: 819285899}
+  - component: {fileID: 819285898}
+  m_Layer: 5
+  m_Name: FlashOverlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &819285898
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 819285897}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1f4bf472f5e246e78f328f21b10a4ce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  flashColor: {r: 0.2, g: 0.85, b: 0.35, a: 1}
+  duration: 1.5
+  peakAlpha: 0.5
+  quadDistance: 0.3
+  coverageMargin: 1.4
+--- !u!114 &819285899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 819285897}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.764151, b: 0.021669416, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &819285900
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 819285897}
+  m_CullTransparentMesh: 1
+--- !u!224 &819285901
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 819285897}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 476612519}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &962975830
 GameObject:
   m_ObjectHideFlags: 0
@@ -839,9 +1000,9 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1936135108}
-  - {fileID: 321373839}
   - {fileID: 760095028}
+  - {fileID: 321373839}
+  - {fileID: 1936135108}
   m_Father: {fileID: 476612519}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -913,150 +1074,6 @@ MonoBehaviour:
   m_ChildScaleWidth: 1
   m_ChildScaleHeight: 1
   m_ReverseArrangement: 0
---- !u!1 &1463179990
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1463179991}
-  - component: {fileID: 1463179993}
-  - component: {fileID: 1463179992}
-  m_Layer: 5
-  m_Name: Image
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1463179991
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1463179990}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 760095028}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1463179992
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1463179990}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1463179993
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1463179990}
-  m_CullTransparentMesh: 1
---- !u!1001 &467610813
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.16
-      objectReference: {fileID: 0}
-    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.272
-      objectReference: {fileID: 0}
-    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.89
-      objectReference: {fileID: 0}
-    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 294005132753942053, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 530999540994195327, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_Camera
-      value: 
-      objectReference: {fileID: 108399580}
-    - target: {fileID: 8715221860109088846, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_Name
-      value: GrabbableVitalsMenu
-      objectReference: {fileID: 0}
-    - target: {fileID: 8715221860109088846, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8768581901916219118, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
-      propertyPath: m_PresetInfoIsWorld
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 36bc2e0e8ae724a91b07c8726c2888f8, type: 3}
 --- !u!1001 &1181496882
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1163,6 +1180,203 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 8825100611093449677, guid: f520c6b2f608a43c2864a7b861579e59, type: 3}
   m_PrefabInstance: {fileID: 1181496882}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1419207190
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1419207192}
+  - component: {fileID: 1419207191}
+  m_Layer: 0
+  m_Name: LtvSceneBootstrapper
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1419207191
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1419207190}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7fe3ef8acdc2405fa139a92ae28824f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  instructionService: {fileID: 1773227994}
+  flashOverlay: {fileID: 819285898}
+  returnSceneName: Mission
+  returnDelaySeconds: 3
+  runWithoutVoiceTrigger: 0
+  enableDebugLogs: 1
+--- !u!4 &1419207192
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1419207190}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.20947142, y: 1.6597596, z: 0.47089064}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1463179990
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1463179991}
+  - component: {fileID: 1463179993}
+  - component: {fileID: 1463179992}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1463179991
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1463179990}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 760095028}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1463179992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1463179990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1463179993
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1463179990}
+  m_CullTransparentMesh: 1
+--- !u!1001 &1644719095
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 759178111942274802, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+      propertyPath: m_Name
+      value: TssUnityApiService
+      objectReference: {fileID: 0}
+    - target: {fileID: 1648704197228427930, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1648704197228427930, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1648704197228427930, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1648704197228427930, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1648704197228427930, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1648704197228427930, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1648704197228427930, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1648704197228427930, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1648704197228427930, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1648704197228427930, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177212473821427495, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+      propertyPath: tssHost
+      value: 10.207.89.182
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+--- !u!114 &1644719096 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3177212473821427495, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
+  m_PrefabInstance: {fileID: 1644719095}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e763e881eb0df45e1a1978531d3091c7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1694539170
 GameObject:
   m_ObjectHideFlags: 0
@@ -1266,9 +1480,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1773227992}
-  - component: {fileID: 1773227991}
-  - component: {fileID: 1773227990}
-  - component: {fileID: 1773227993}
   - component: {fileID: 1773227994}
   m_Layer: 0
   m_Name: LtvServices
@@ -1277,36 +1488,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1773227990
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1773227989}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e763e881eb0df45e1a1978531d3091c7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tssHost: 192.168.1.210
-  tssPort: 14141
-  pollIntervalSeconds: 0.25
-  udpTimeoutMs: 500
-  udpRetries: 2
-  ltvProceduresJson: {fileID: 0}
---- !u!114 &1773227991
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1773227989}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e7cef459282e34521ad977df6b05ec21, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &1773227992
 Transform:
   m_ObjectHideFlags: 0
@@ -1322,18 +1503,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1773227993
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1773227989}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8c7a2fe0f5f4344849e9ddafdf64033a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1773227994
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1346,7 +1515,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4c3b5324139545379ccc7bd728544b33, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  tssApi: {fileID: 1773227990}
+  tssApi: {fileID: 1644719096}
   verificationPollSeconds: 1
   verificationTimeoutSeconds: 10
   errorListRefreshSeconds: 1
@@ -1449,44 +1618,14 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1936135107}
   m_CullTransparentMesh: 1
---- !u!1 &1995127802
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1995127803}
-  m_Layer: 0
-  m_Name: 'TssUnityApiService (Missing Prefab with guid: d4ffbdc4a993a44cda05f2eab6317851)'
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1995127803
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1995127802}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1694539172}
   - {fileID: 108399579}
-  - {fileID: 1995127803}
   - {fileID: 476612519}
   - {fileID: 1773227992}
   - {fileID: 467610813}
+  - {fileID: 1419207192}
+  - {fileID: 1644719095}

--- a/Assets/Scenes/final_scenes/Mission.unity
+++ b/Assets/Scenes/final_scenes/Mission.unity
@@ -38,7 +38,6 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028356, g: 0.2257137, b: 0.3069222, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -123,97 +122,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &224362098
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3538298739891595076, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-      propertyPath: m_Name
-      value: MinimapManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 3874339659801022743, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 664.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3874339659801022743, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 542
-      objectReference: {fileID: 0}
-    - target: {fileID: 3874339659801022743, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3874339659801022743, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3874339659801022743, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3874339659801022743, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3874339659801022743, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3874339659801022743, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3874339659801022743, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3874339659801022743, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 6675888194535002470, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3538298739891595076, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 224362100}
-  m_SourcePrefab: {fileID: 100100000, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
---- !u!1 &224362099 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3538298739891595076, guid: 7708feb849a6a496bbb65d267f28cf23, type: 3}
-  m_PrefabInstance: {fileID: 224362098}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &224362100
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 224362099}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f5bec82ec592540aab90e546219d13cf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tssApi: {fileID: 1138549943}
-  evaId: eva1
-  minimapRect: {fileID: 878749584}
-  playerIcon: {fileID: 498685380}
-  pathContainer: {fileID: 498685380}
-  trailDotPrefab: {fileID: 7200025896239442515, guid: 6cdfbe42c70d7407dad326a68c5f9f79, type: 3}
-  mapMinX: -5765
-  mapMaxX: -5545
-  mapMinY: -10075
-  mapMaxY: -9940
-  recordDistance: 0.25
-  verboseDebug: 1
-  logIntervalSeconds: 1
 --- !u!1 &275567183
 GameObject:
   m_ObjectHideFlags: 0
@@ -229,7 +137,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &275567184
 Transform:
   m_ObjectHideFlags: 0
@@ -246,81 +154,6 @@ Transform:
   - {fileID: 927401646}
   m_Father: {fileID: 1350499926}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &498685379
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 498685380}
-  - component: {fileID: 498685382}
-  - component: {fileID: 498685381}
-  m_Layer: 5
-  m_Name: PlayerIcon
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &498685380
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 498685379}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 878749584}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 100, y: 100}
-  m_SizeDelta: {x: 15, y: 15}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &498685381
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 498685379}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.8867924, g: 0.13803846, b: 0.13803846, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &498685382
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 498685379}
-  m_CullTransparentMesh: 1
 --- !u!1 &809889376
 GameObject:
   m_ObjectHideFlags: 0
@@ -360,10 +193,10 @@ MonoBehaviour:
   responseTextBox: {fileID: 0}
   voskSpeechToText: {fileID: 0}
   voiceProcessor: {fileID: 0}
-  voskModelPath: vosk-model-small-en-us-0.15.zip
+  voskModelPath: vosk-model-en-us-0.22-lgraph.zip
   maxAlternatives: 1
   initializationTimeoutSeconds: 120
-  silenceStopSeconds: 2
+  silenceStopSeconds: 5
   logTranscripts: 1
 --- !u!114 &809889378
 MonoBehaviour:
@@ -455,7 +288,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 809889376}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.5}
+  m_LocalPosition: {x: 0, y: 0, z: 0.637}
   m_LocalScale: {x: 0.001, y: 0.001, z: 0.001}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -464,7 +297,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -0.5, y: 1.025}
   m_SizeDelta: {x: 800, y: 600}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &872049072
@@ -657,84 +490,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bd7cd5a4aebf8422ea169808fede90fd, type: 3}
---- !u!1 &878749583
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 878749584}
-  - component: {fileID: 878749587}
-  - component: {fileID: 878749586}
-  m_Layer: 5
-  m_Name: MinimapBackground
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &878749584
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 878749583}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
-  m_Children:
-  - {fileID: 498685380}
-  - {fileID: 1086432412}
-  - {fileID: 2058437517}
-  m_Father: {fileID: 1154997368}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 200}
-  m_Pivot: {x: 0, y: 1}
---- !u!114 &878749586
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 878749583}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.44705886, g: 0.427451, b: 0.41960788, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 3e717501633d84f4aa9a9722636abbaf, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &878749587
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 878749583}
-  m_CullTransparentMesh: 1
 --- !u!1 &896917018
 GameObject:
   m_ObjectHideFlags: 0
@@ -761,17 +516,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 896917018}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1453129407}
   m_Father: {fileID: 1154997368}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 118, y: 100}
+  m_AnchoredPosition: {x: 660, y: 520.7}
   m_SizeDelta: {x: 220, y: 44}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &896917020
@@ -1163,81 +918,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 973456670}
   m_CullTransparentMesh: 1
---- !u!1 &1086432411
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1086432412}
-  - component: {fileID: 1086432414}
-  - component: {fileID: 1086432413}
-  m_Layer: 5
-  m_Name: PathContainer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1086432412
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1086432411}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 878749584}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1086432413
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1086432411}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1086432414
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1086432411}
-  m_CullTransparentMesh: 1
 --- !u!1 &1138549942
 GameObject:
   m_ObjectHideFlags: 0
@@ -1266,8 +946,8 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e763e881eb0df45e1a1978531d3091c7, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
-  tssHost: 192.168.2.1
+  m_EditorClassIdentifier:
+  tssHost: 10.207.89.182
   tssPort: 14141
   pollIntervalSeconds: 0.25
   udpTimeoutMs: 500
@@ -1320,8 +1000,6 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 878749584}
-  - {fileID: 1959078925}
   - {fileID: 1963959655}
   - {fileID: 896917019}
   m_Father: {fileID: 809889382}
@@ -1357,7 +1035,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1154997367}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
   m_Name: 
@@ -1515,61 +1193,17 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 5604462856219005995, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
-      propertyPath: m_ClearFlags
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604462856219005995, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
-      propertyPath: m_BackGroundColor.a
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604462856219005995, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
-      propertyPath: m_BackGroundColor.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604462856219005995, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
-      propertyPath: m_BackGroundColor.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604462856219005995, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
-      propertyPath: m_BackGroundColor.r
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604462856219005998, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
+    - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604462856219005998, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604462856219005998, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604462856267450383, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.393
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604462856267450383, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.178
-      objectReference: {fileID: 0}
-    - target: {fileID: 5604462856267450383, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
-      propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.481
-      objectReference: {fileID: 0}
-    - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.284
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.3658
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8358158060413148696, guid: ce09d09d51cc549ef96d44a36953006b, type: 3}
       propertyPath: m_LocalRotation.w
@@ -1700,140 +1334,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1453129406}
   m_CullTransparentMesh: 1
---- !u!1 &1467994618
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1467994619}
-  - component: {fileID: 1467994621}
-  - component: {fileID: 1467994620}
-  m_Layer: 5
-  m_Name: text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1467994619
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1467994618}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2058437517}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1467994620
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1467994618}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: 
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 0}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &1467994621
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1467994618}
-  m_CullTransparentMesh: 1
 --- !u!1 &1469075974
 GameObject:
   m_ObjectHideFlags: 0
@@ -1909,6 +1409,51 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1469075974}
   m_CullTransparentMesh: 1
+--- !u!1 &1538358367
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1538358369}
+  - component: {fileID: 1538358368}
+  m_Layer: 0
+  m_Name: LunaTtsBridge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1538358368
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1538358367}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3ded4bc3dabc04449a056109cffa72db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  logSpokenText: 1
+--- !u!4 &1538358369
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1538358367}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.20947142, y: 1.6597596, z: 0.47089064}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1607032825
 GameObject:
   m_ObjectHideFlags: 0
@@ -1949,6 +1494,7 @@ MonoBehaviour:
   responseTextBox: {fileID: 0}
   aiaInputController: {fileID: 0}
   responseScrollRect: {fileID: 0}
+  ltvVoiceCoordinator: {fileID: 1944448547}
   verboseVoiceLogging: 1
 --- !u!4 &1607032827
 Transform:
@@ -1965,7 +1511,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1833556500
+--- !u!1 &1944448546
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1973,305 +1519,48 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1833556504}
-  - component: {fileID: 1833556503}
-  - component: {fileID: 1833556502}
-  - component: {fileID: 1833556501}
-  m_Layer: 5
-  m_Name: NavCanvas
+  - component: {fileID: 1944448548}
+  - component: {fileID: 1944448547}
+  m_Layer: 0
+  m_Name: LtvVoiceCoordinator
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!114 &1833556501
+  m_IsActive: 1
+--- !u!114 &1944448547
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1833556500}
+  m_GameObject: {fileID: 1944448546}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Script: {fileID: 11500000, guid: 9c12f3bab58fb4de5a7e17fcd66e743f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &1833556502
-MonoBehaviour:
+  ltvSceneName: LTV
+  triggerPhrases:
+  - start repair
+  - ltv-repair
+  - lt v repair
+  enableDebugLogs: 1
+--- !u!4 &1944448548
+Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1833556500}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!223 &1833556503
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1833556500}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 1
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 0.5
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 25
-  m_UpdateRectTransformForStandalone: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!224 &1833556504
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1833556500}
+  m_GameObject: {fileID: 1944448546}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.20947142, y: 1.6597596, z: 0.47089064}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
---- !u!1 &1857583986
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1857583987}
-  - component: {fileID: 1857583989}
-  - component: {fileID: 1857583988}
-  m_Layer: 5
-  m_Name: Needle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1857583987
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1857583986}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1959078925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 135, y: 221.9}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1857583988
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1857583986}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 807b4eea7c4e24ae09c683093c364848, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1857583989
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1857583986}
-  m_CullTransparentMesh: 1
---- !u!1 &1931033187
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1931033188}
-  - component: {fileID: 1931033190}
-  - component: {fileID: 1931033189}
-  m_Layer: 5
-  m_Name: Compass_Circle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1931033188
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1931033187}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
-  m_Children: []
-  m_Father: {fileID: 1959078925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 135, y: 222}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1931033189
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1931033187}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 959e2014044a940dabc00ee6811d69db, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1931033190
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1931033187}
-  m_CullTransparentMesh: 1
---- !u!1 &1959078924
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1959078925}
-  - component: {fileID: 1959078926}
-  m_Layer: 0
-  m_Name: Compass
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1959078925
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1959078924}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
-  m_Children:
-  - {fileID: 1931033188}
-  - {fileID: 1857583987}
-  m_Father: {fileID: 1154997368}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -300, y: -350}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1959078926
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1959078924}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0ae66a638550e49bdaad75f24463fda3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tssApi: {fileID: 1138549943}
-  evaId: eva1
-  NorthArrow: {fileID: 1931033188}
-  useTssHeading: 1
-  debugHeading: 0
-  logIntervalSeconds: 1
 --- !u!1 &1963959654
 GameObject:
   m_ObjectHideFlags: 0
@@ -2301,14 +1590,14 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 973456671}
   m_Father: {fileID: 1154997368}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 115, y: 17}
+  m_AnchoredPosition: {x: 660, y: 459.9999}
   m_SizeDelta: {x: 220, y: 44}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &1963959656
@@ -2405,139 +1694,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1963959654}
   m_CullTransparentMesh: 1
---- !u!1 &2058437516
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2058437517}
-  - component: {fileID: 2058437520}
-  - component: {fileID: 2058437519}
-  - component: {fileID: 2058437518}
-  m_Layer: 5
-  m_Name: Button
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &2058437517
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2058437516}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1467994619}
-  m_Father: {fileID: 878749584}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 200}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &2058437518
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2058437516}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 2058437519}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: MinimapToggle, Assembly-CSharp
-        m_MethodName: Toggle
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!114 &2058437519
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2058437516}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &2058437520
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2058437516}
-  m_CullTransparentMesh: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -2549,5 +1705,5 @@ SceneRoots:
   - {fileID: 809889382}
   - {fileID: 1350499924}
   - {fileID: 872049072}
-  - {fileID: 1833556504}
-  - {fileID: 224362098}
+  - {fileID: 1538358369}
+  - {fileID: 1944448548}


### PR DESCRIPTION
## Summary
- New LTV repair flow: body-locked HUD (XR Hands), full-FOV camera-attached flash overlay, auto-return to Mission on completion, enlarged checkmark with padded raycast.
- Voice routing: MLVoice intents 106–108 (`ltv repair` / `start ltv repair` / `begin ltv repair`) bypass Vosk and trigger the LTV coordinator directly. Vosk partial-transcript path also routes LTV-repair locally so the command fires without waiting on ML2's flaky silence detection.
- New persistent `LunaTtsBridge` TTS singleton survives scene transitions; `VoiceIntents` skips inline Android TTS when a bridge is present, preventing two `TextToSpeech` engines from competing on ML2.
- Procedure parser (`LtvInstructionService`): tolerates `17.To` no-space step markers; splits concatenated procedure strings into one step per click.

## Scope
Squashed from 17 commits on `init-and-end`, filtered to **AIA + LTV + scene** files only. The following are intentionally **excluded** from this PR:
- `Assets/TSS-API/*` (UDP retry logging + poll-snapshot diagnostics)
- `Assets/TextMesh Pro/*` (TMP Essentials vendor drop)
- `Packages/*`, `ProjectSettings/*` (project + package config)

## Files changed (14)
```
Assets/AIA/AIAVoskInputController.cs
Assets/AIA/LunaTtsBridge.cs                (new)
Assets/AIA/LunaTtsBridge.cs.meta           (new)
Assets/AIA/MLVoiceIntentsConfiguration.asset
Assets/AIA/VoiceIntents.cs
Assets/LTV/LtvFlashOverlay.cs              (new)
Assets/LTV/LtvFlashOverlay.cs.meta         (new)
Assets/LTV/LtvInstructionService.cs
Assets/LTV/LtvSceneBootstrapper.cs         (new)
Assets/LTV/LtvSceneBootstrapper.cs.meta    (new)
Assets/LTV/LtvVoiceCoordinator.cs          (new)
Assets/LTV/LtvVoiceCoordinator.cs.meta     (new)
Assets/Scenes/final_scenes/LTV.unity
Assets/Scenes/final_scenes/Mission.unity
```

## Test plan
- [ ] Project opens in Unity without compile errors (no missing references from excluded TSS-API/TMP changes)
- [ ] Mission scene loads; voice "ltv repair" / "start ltv repair" / "begin ltv repair" triggers transition to LTV scene via MLVoice path
- [ ] Vosk partial-transcript path also triggers LTV-repair on the same phrases (with MLVoice disabled)
- [ ] LTV repair flow: TTS plays start prompt, HUD body-locks, flash overlay covers full FOV, checkmark dismisses, returns to Mission
- [ ] Only one TTS engine speaks (no overlap between LunaTtsBridge and inline Android TTS)
- [ ] Procedure splitter handles concatenated strings and `17.To` markers correctly