### PR TITLE
feat(voice): cross-scene voice transitions via SceneVoiceCoordinator

### DIFF
--- a/Assets/AIA/AIAVoskInputController.cs
+++ b/Assets/AIA/AIAVoskInputController.cs
@@ -166,9 +166,9 @@ public class AIAVoskInputController : MonoBehaviour
     private bool isVoskInitializing;
     private bool isVoskInitialized;
     private bool isRecording;
-    // Set true once a partial transcript routes the LTV-repair command this session,
+    // Set true once a partial transcript routes a scene-transition command this session,
     // so subsequent partials don't double-trigger before recording stops.
-    private bool _routedLtvRepairThisSession;
+    private bool _routedSceneVoiceThisSession;
     private Coroutine initializationTimeoutCoroutine;
 
     private void Awake()
@@ -276,10 +276,17 @@ public class AIAVoskInputController : MonoBehaviour
     {
         if (voiceIntents == null)
         {
-            GameObject voiceIntentObject = GameObject.Find("VoiceIntent");
-            if (voiceIntentObject != null)
+            // Prefer the persistent singleton: a freshly-loaded scene's local VoiceIntent
+            // briefly coexists with the persistent one during the same frame, and
+            // GameObject.Find can return the doomed duplicate before its Destroy resolves.
+            voiceIntents = VoiceIntents.Instance;
+            if (voiceIntents == null)
             {
-                voiceIntents = voiceIntentObject.GetComponent<VoiceIntents>();
+                GameObject voiceIntentObject = GameObject.Find("VoiceIntent");
+                if (voiceIntentObject != null)
+                {
+                    voiceIntents = voiceIntentObject.GetComponent<VoiceIntents>();
+                }
             }
         }
 
@@ -442,7 +449,7 @@ public class AIAVoskInputController : MonoBehaviour
 
         try
         {
-            _routedLtvRepairThisSession = false;
+            _routedSceneVoiceThisSession = false;
 
             if (voiceIntents != null)
             {
@@ -591,14 +598,14 @@ public class AIAVoskInputController : MonoBehaviour
                 voiceIntents.UpdateRecordingTranscript(partialTranscript);
 
                 // VoiceProcessor's silence detection on ML2 doesn't reliably fire, so the
-                // recording stays open and the final transcript never emits. Route LTV-repair
-                // off the live partial stream instead — fires the moment Vosk has heard
-                // enough audio to recognize the command.
-                if (!_routedLtvRepairThisSession &&
-                    voiceIntents.TryRouteLtvRepairCommand(partialTranscript))
+                // recording stays open and the final transcript never emits. Route scene
+                // transitions off the live partial stream instead — fires the moment Vosk
+                // has heard enough audio to recognize a configured command.
+                if (!_routedSceneVoiceThisSession &&
+                    voiceIntents.TryRouteSceneVoiceCommand(partialTranscript))
                 {
-                    _routedLtvRepairThisSession = true;
-                    Debug.Log($"[Vosk] LTV-repair routed from partial transcript: '{partialTranscript}'. Stopping recording.");
+                    _routedSceneVoiceThisSession = true;
+                    Debug.Log($"[Vosk] Scene-voice command routed from partial transcript: '{partialTranscript}'. Stopping recording.");
                     StopRecording();
                 }
             }

--- a/Assets/AIA/MLVoiceIntentsConfiguration.asset
+++ b/Assets/AIA/MLVoiceIntentsConfiguration.asset
@@ -30,6 +30,16 @@ MonoBehaviour:
     Value: start ltv repair
   - Id: 108
     Value: begin ltv repair
+  - Id: 109
+    Value: start egress
+  - Id: 110
+    Value: start mission
+  - Id: 111
+    Value: start ingress
+  - Id: 112
+    Value: end ingress
+  - Id: 113
+    Value: end ltv repair
   AutoAllowAllSystemIntents: 0
   SystemCommands: 0
   SlotsForVoiceCommands: []

--- a/Assets/AIA/VoiceIntents.cs
+++ b/Assets/AIA/VoiceIntents.cs
@@ -10,11 +10,17 @@ using UnityEngine.XR.MagicLeap;
 
 public class VoiceIntents : MonoBehaviour
 {
+    public static VoiceIntents Instance { get; private set; }
+
     private const uint AskLunaEventId = 105;
     // MLVoice intent IDs that route directly to LTV-repair (bypasses Vosk).
     // Configured in Assets/AIA/MLVoiceIntentsConfiguration.asset.
     private const uint LtvRepairEventIdMin = 106;
     private const uint LtvRepairEventIdMax = 108;
+    // MLVoice intent IDs that route to generic scene transitions via SceneVoiceCoordinator.
+    // Configured in Assets/AIA/MLVoiceIntentsConfiguration.asset.
+    private const uint SceneTransitionEventIdMin = 109;
+    private const uint SceneTransitionEventIdMax = 113;
     private const int AiRequestTimeoutSeconds = 30;
     private const string OllamaIpEnvironmentVariable = "LUNA_OLLAMA_IP";
     private const int MaxVisibleConversationTurns = 3;
@@ -42,6 +48,11 @@ public class VoiceIntents : MonoBehaviour
     [Tooltip("Optional LTV-repair voice coordinator. If present and the transcript matches its " +
              "trigger phrases, the prompt is consumed locally instead of being forwarded to Gemma.")]
     [SerializeField] private LtvVoiceCoordinator ltvVoiceCoordinator;
+
+    [Tooltip("Optional generic scene-transition voice coordinator (persistent singleton). " +
+             "Handles all voice transitions other than the Mission→LTV entry, which stays " +
+             "on LtvVoiceCoordinator so LtvSceneBootstrapper still sees PendingVoiceTrigger.")]
+    [SerializeField] private SceneVoiceCoordinator sceneVoiceCoordinator;
 
     [Header("Debugging")]
     [SerializeField] private bool verboseVoiceLogging = true;
@@ -143,6 +154,15 @@ public class VoiceIntents : MonoBehaviour
 
     private void Awake()
     {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
         permissionCallbacks.OnPermissionGranted += OnPermissionGranted;
         permissionCallbacks.OnPermissionDenied += OnPermissionDenied;
         permissionCallbacks.OnPermissionDeniedAndDontAskAgain += OnPermissionDenied;
@@ -150,6 +170,11 @@ public class VoiceIntents : MonoBehaviour
 
     private void OnDestroy()
     {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+
         permissionCallbacks.OnPermissionGranted -= OnPermissionGranted;
         permissionCallbacks.OnPermissionDenied -= OnPermissionDenied;
         permissionCallbacks.OnPermissionDeniedAndDontAskAgain -= OnPermissionDenied;
@@ -290,9 +315,20 @@ public class VoiceIntents : MonoBehaviour
                     string spokenPhrase = string.IsNullOrWhiteSpace(voiceEvent.EventName)
                         ? "ltv repair"
                         : voiceEvent.EventName;
-                    if (!TryRouteLtvRepairCommand(spokenPhrase))
+                    if (!TryRouteSceneVoiceCommand(spokenPhrase))
                     {
                         Debug.LogWarning("[Luna] LTV-repair MLVoice intent matched but coordinator did not accept it.");
+                    }
+                }
+                else if (voiceEvent.EventID >= SceneTransitionEventIdMin && voiceEvent.EventID <= SceneTransitionEventIdMax)
+                {
+                    Debug.Log($"[Luna] Scene-transition MLVoice intent fired (id={voiceEvent.EventID}, name='{voiceEvent.EventName}')");
+                    string spokenPhrase = string.IsNullOrWhiteSpace(voiceEvent.EventName)
+                        ? string.Empty
+                        : voiceEvent.EventName;
+                    if (!TryRouteSceneVoiceCommand(spokenPhrase))
+                    {
+                        Debug.LogWarning($"[Luna] Scene-transition MLVoice intent '{voiceEvent.EventName}' did not match any configured transition in the current scene.");
                     }
                 }
                 else
@@ -359,23 +395,33 @@ public class VoiceIntents : MonoBehaviour
     }
 
     /// <summary>
-    /// Public so AIAVoskInputController can fire LTV-repair routing on partial Vosk
-    /// transcripts (without waiting for the recording to stop and a final result to
-    /// emit). Returns true when the transcript matched and the LTV scene was loaded.
+    /// Public so AIAVoskInputController can fire scene-transition routing on partial
+    /// Vosk transcripts (without waiting for the recording to stop and a final result
+    /// to emit). Tries the generic <see cref="SceneVoiceCoordinator"/> first (any
+    /// scene-to-scene transition), then falls back to <see cref="LtvVoiceCoordinator"/>
+    /// (kept for the Mission→LTV entry because LtvSceneBootstrapper consumes its
+    /// PendingVoiceTrigger flag). Returns true when a transition fired.
     /// </summary>
-    public bool TryRouteLtvRepairCommand(string trimmedPrompt)
+    public bool TryRouteSceneVoiceCommand(string trimmedPrompt)
     {
+        if (sceneVoiceCoordinator == null)
+        {
+            sceneVoiceCoordinator = SceneVoiceCoordinator.Instance != null
+                ? SceneVoiceCoordinator.Instance
+                : FindObjectOfType<SceneVoiceCoordinator>();
+        }
+
+        if (sceneVoiceCoordinator != null && sceneVoiceCoordinator.TryHandleVoiceCommand(trimmedPrompt))
+        {
+            return true;
+        }
+
         if (ltvVoiceCoordinator == null)
         {
             ltvVoiceCoordinator = FindObjectOfType<LtvVoiceCoordinator>();
         }
 
-        if (ltvVoiceCoordinator == null)
-        {
-            return false;
-        }
-
-        return ltvVoiceCoordinator.TryHandleVoiceCommand(trimmedPrompt);
+        return ltvVoiceCoordinator != null && ltvVoiceCoordinator.TryHandleVoiceCommand(trimmedPrompt);
     }
 
     private void UpdateResponseTextBox(string text)
@@ -468,11 +514,11 @@ public class VoiceIntents : MonoBehaviour
             return;
         }
 
-        if (TryRouteLtvRepairCommand(trimmedPrompt))
+        if (TryRouteSceneVoiceCommand(trimmedPrompt))
         {
-            // The coordinator will load the LTV scene and run the repair flow.
+            // A scene-transition coordinator consumed the prompt and queued a LoadScene.
             // We intentionally do NOT forward this transcript to Gemma.
-            CompleteActiveConversation("Loading LTV repair console.");
+            CompleteActiveConversation("Loading next scene.");
             return;
         }
 

--- a/Assets/Scenes/SceneVoiceCoordinator.cs
+++ b/Assets/Scenes/SceneVoiceCoordinator.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Persistent (DontDestroyOnLoad) voice coordinator that maps trigger phrases to
+/// scene transitions. One instance lives in the bootstrap scene (Mission) and
+/// survives every subsequent <see cref="SceneManager.LoadScene(string)"/> call.
+///
+/// Each <see cref="SceneVoiceTransition"/> entry binds a source scene name + a
+/// list of trigger phrases to a target scene + an optional spoken announcement.
+/// <see cref="TryHandleVoiceCommand"/> filters the transition list by the
+/// currently active scene before matching, so the same phrase can mean
+/// different things in different scenes (e.g. "start mission" is only valid
+/// from Ingress).
+///
+/// LTV-specific entry (Mission → LTV) intentionally stays on
+/// <see cref="LtvVoiceCoordinator"/> because the LTV scene's bootstrapper
+/// consumes its <see cref="LtvVoiceCoordinator.PendingVoiceTrigger"/> flag. The
+/// LTV → Mission return direction is configured here.
+/// </summary>
+public class SceneVoiceCoordinator : MonoBehaviour
+{
+    public static SceneVoiceCoordinator Instance { get; private set; }
+
+    [Serializable]
+    public class SceneVoiceTransition
+    {
+        [Tooltip("Active scene name (SceneManager.GetActiveScene().name) for which this transition is valid.")]
+        public string sourceSceneName;
+
+        [Tooltip("Case-insensitive substring(s) that trigger this transition. " +
+                 "Whitespace and punctuation are normalized before matching.")]
+        public string[] triggerPhrases;
+
+        [Tooltip("Scene to load. Must be in Build Settings.")]
+        public string targetSceneName;
+
+        [Tooltip("Optional sentence spoken via LunaTtsBridge before the scene loads. " +
+                 "Leave blank for a silent transition.")]
+        public string announcement;
+    }
+
+    [Tooltip("All voice-driven scene transitions. Filtered by current scene at runtime.")]
+    public SceneVoiceTransition[] transitions;
+
+    [Tooltip("Log every transcript we evaluate, even non-matching ones. Off in flight.")]
+    public bool enableDebugLogs = true;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+    }
+
+    /// <summary>
+    /// Returns true if the transcript matched a transition for the active
+    /// scene and the load was queued. Callers should suppress further routing
+    /// (e.g. the AI submit path) when this returns true.
+    /// </summary>
+    public bool TryHandleVoiceCommand(string transcript)
+    {
+        if (string.IsNullOrWhiteSpace(transcript) || transitions == null || transitions.Length == 0)
+        {
+            return false;
+        }
+
+        string currentSceneName = SceneManager.GetActiveScene().name;
+        string normalizedTranscript = NormalizeForMatch(transcript);
+
+        for (int i = 0; i < transitions.Length; i++)
+        {
+            SceneVoiceTransition transition = transitions[i];
+            if (transition == null) continue;
+            if (string.IsNullOrWhiteSpace(transition.sourceSceneName)) continue;
+            if (!string.Equals(transition.sourceSceneName, currentSceneName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            if (transition.triggerPhrases == null || transition.triggerPhrases.Length == 0) continue;
+            if (string.IsNullOrWhiteSpace(transition.targetSceneName)) continue;
+
+            for (int j = 0; j < transition.triggerPhrases.Length; j++)
+            {
+                string phrase = transition.triggerPhrases[j];
+                if (string.IsNullOrWhiteSpace(phrase)) continue;
+                if (normalizedTranscript.IndexOf(NormalizeForMatch(phrase), StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    continue;
+                }
+
+                if (enableDebugLogs)
+                {
+                    Debug.Log(
+                        $"[SceneVoice] Matched '{phrase}' in scene '{currentSceneName}' " +
+                        $"(transcript='{transcript}'). Loading '{transition.targetSceneName}'.", this);
+                }
+
+                if (!string.IsNullOrWhiteSpace(transition.announcement))
+                {
+                    LunaTtsBridge.Instance?.Speak(transition.announcement);
+                }
+
+                SceneManager.LoadScene(transition.targetSceneName);
+                return true;
+            }
+        }
+
+        if (enableDebugLogs)
+        {
+            Debug.Log(
+                $"[SceneVoice] No transition matched in scene '{currentSceneName}'. " +
+                $"Transcript: '{transcript}' (normalized='{normalizedTranscript}').", this);
+        }
+
+        return false;
+    }
+
+    private static string NormalizeForMatch(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+        return Regex.Replace(text.ToLowerInvariant(), "[^a-z0-9]+", " ").Trim();
+    }
+}

--- a/Assets/Scenes/SceneVoiceCoordinator.cs.meta
+++ b/Assets/Scenes/SceneVoiceCoordinator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c4f30f8028d4e798497b6ab1926bcbf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/final_scenes/Mission.unity
+++ b/Assets/Scenes/final_scenes/Mission.unity
@@ -1495,6 +1495,7 @@ MonoBehaviour:
   aiaInputController: {fileID: 0}
   responseScrollRect: {fileID: 0}
   ltvVoiceCoordinator: {fileID: 1944448547}
+  sceneVoiceCoordinator: {fileID: 7700000002}
   verboseVoiceLogging: 1
 --- !u!4 &1607032827
 Transform:
@@ -1694,6 +1695,79 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1963959654}
   m_CullTransparentMesh: 1
+--- !u!1 &7700000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7700000003}
+  - component: {fileID: 7700000002}
+  m_Layer: 0
+  m_Name: SceneVoiceCoordinator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &7700000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7700000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c4f30f8028d4e798497b6ab1926bcbf, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  transitions:
+  - sourceSceneName: Starter
+    triggerPhrases:
+    - start egress
+    targetSceneName: Egress
+    announcement: Starting egress.
+  - sourceSceneName: Egress
+    triggerPhrases:
+    - start mission
+    targetSceneName: Mission
+    announcement: Starting mission.
+  - sourceSceneName: Mission
+    triggerPhrases:
+    - start ingress
+    targetSceneName: Ingress
+    announcement: Starting ingress.
+  - sourceSceneName: Ingress
+    triggerPhrases:
+    - end ingress
+    targetSceneName: Starter
+    announcement: Ending ingress.
+  - sourceSceneName: LTV
+    triggerPhrases:
+    - end ltv repair
+    - end l t v repair
+    - end ltv-repair
+    targetSceneName: Mission
+    announcement: Returning to Mission.
+  enableDebugLogs: 1
+--- !u!4 &7700000003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7700000001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1707,3 +1781,4 @@ SceneRoots:
   - {fileID: 872049072}
   - {fileID: 1538358369}
   - {fileID: 1944448548}
+  - {fileID: 7700000003}

--- a/Assets/Scenes/final_scenes/Starter.unity
+++ b/Assets/Scenes/final_scenes/Starter.unity
@@ -904,6 +904,182 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &3100000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3100000003}
+  - component: {fileID: 3100000002}
+  m_Layer: 0
+  m_Name: LunaTtsBridge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &3100000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3100000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3ded4bc3dabc04449a056109cffa72db, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  logSpokenText: 1
+--- !u!4 &3100000003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3100000001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3100000011
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3100000013}
+  - component: {fileID: 3100000012}
+  m_Layer: 0
+  m_Name: VoiceIntent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &3100000012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3100000011}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f0d4c99cad10499c874c5f87a0f0960, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  VoiceIntentsConfiguration: {fileID: 11400000, guid: bc0d55f56ba294532829093db7f9abb8, type: 2}
+  targetObject: {fileID: 0}
+  rotationSpeed: 50
+  sendVoicePromptToAi: 1
+  aiGenerateUrl: http://10.206.9.135:13853/chat
+  aiModel: gemma4:26b
+  logAiResponse: 1
+  speakAiResponse: 1
+  responseTextBox: {fileID: 0}
+  aiaInputController: {fileID: 0}
+  responseScrollRect: {fileID: 0}
+  ltvVoiceCoordinator: {fileID: 0}
+  sceneVoiceCoordinator: {fileID: 3100000022}
+  verboseVoiceLogging: 1
+--- !u!4 &3100000013
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3100000011}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3100000021
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3100000023}
+  - component: {fileID: 3100000022}
+  m_Layer: 0
+  m_Name: SceneVoiceCoordinator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &3100000022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3100000021}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c4f30f8028d4e798497b6ab1926bcbf, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  transitions:
+  - sourceSceneName: Starter
+    triggerPhrases:
+    - start egress
+    targetSceneName: Egress
+    announcement: Starting egress.
+  - sourceSceneName: Egress
+    triggerPhrases:
+    - start mission
+    targetSceneName: Mission
+    announcement: Starting mission.
+  - sourceSceneName: Mission
+    triggerPhrases:
+    - start ingress
+    targetSceneName: Ingress
+    announcement: Starting ingress.
+  - sourceSceneName: Ingress
+    triggerPhrases:
+    - end ingress
+    targetSceneName: Starter
+    announcement: Ending ingress.
+  - sourceSceneName: LTV
+    triggerPhrases:
+    - end ltv repair
+    - end l t v repair
+    - end ltv-repair
+    targetSceneName: Mission
+    announcement: Returning to Mission.
+  enableDebugLogs: 1
+--- !u!4 &3100000023
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3100000021}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -913,3 +1089,6 @@ SceneRoots:
   - {fileID: 1502506524}
   - {fileID: 446509664}
   - {fileID: 766268442}
+  - {fileID: 3100000003}
+  - {fileID: 3100000013}
+  - {fileID: 3100000023}

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -5,9 +5,24 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/working_scenes/Thea-UI.unity
     guid: 3b8f2cec444e84f17aa046c9e583d07b
+  - enabled: 1
+    path: Assets/Scenes/final_scenes/Starter.unity
+    guid: 6002158857ea7482ea8717f7bfd0efb1
+  - enabled: 1
+    path: Assets/Scenes/final_scenes/Mission.unity
+    guid: 55d96265320294461b2212e6379667f5
+  - enabled: 1
+    path: Assets/Scenes/final_scenes/LTV.unity
+    guid: fae8df6ac86fa48fc985d18b019670f2
+  - enabled: 1
+    path: Assets/Scenes/final_scenes/Ingress.unity
+    guid: f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6
+  - enabled: 1
+    path: Assets/Scenes/final_scenes/Egress.unity
+    guid: 42d12380eb057498ab3d79e5f84e8a90
   m_configObjects:
     com.unity.xr.management.loader_settings: {fileID: 11400000, guid: c761bc8a9a07b4bbd896483595753c2d, type: 2}
     com.unity.xr.openxr.settings4: {fileID: 11400000, guid: 8ed9a45425179499dbcea186030840ed, type: 2}


### PR DESCRIPTION
## Summary

Wires up voice-driven scene transitions across Starter, Egress, Mission, Ingress, and LTV by generalizing the existing LTV-repair voice routing into a persistent `SceneVoiceCoordinator`.

- New `SceneVoiceCoordinator` (DontDestroyOnLoad + singleton) maps `(sourceScene, phrases) -> (targetScene, announcement)` filtered by the current active scene.
- Persistent voice infra (`LunaTtsBridge`, `VoiceIntent`, `SceneVoiceCoordinator`) lives in Starter and survives every `SceneManager.LoadScene` call, so MLVoice intents fire from every scene without per-scene duplication.
- `VoiceIntents` now routes the generic coordinator first and falls back to `LtvVoiceCoordinator` for the Mission→LTV entry (kept because `LtvSceneBootstrapper` consumes `PendingVoiceTrigger`).
- `AIAVoskInputController` is intentionally left scene-scoped — it lives on Mission's `MainCanvas`, so `DontDestroyOnLoad` on it would drag the Mission UI into other scenes.
- MLVoice intent IDs `109-113` added: `start egress`, `start mission`, `start ingress`, `end ingress`, `end ltv repair`.
- Build settings reordered: Starter is the entry scene; Ingress and Egress added.

### Transitions wired

| Scene | Phrase | Target |
|---|---|---|
| Starter | `start egress` | Egress |
| Egress | `start mission` | Mission |
| Mission | `start ingress` | Ingress |
| Ingress | `end ingress` | Starter |
| LTV | `end ltv repair` | Mission |

Mission→LTV (`ltv repair` / `start ltv repair` / `begin ltv repair`) continues to flow through the existing `LtvVoiceCoordinator`.