### PR TITLE
add HUD visibility toggle via open-palm gesture + voice

### DIFF
--- a/Assets/AIA/MLVoiceIntentsConfiguration.asset
+++ b/Assets/AIA/MLVoiceIntentsConfiguration.asset
@@ -40,6 +40,10 @@ MonoBehaviour:
     Value: end ingress
   - Id: 113
     Value: end ltv repair
+  - Id: 114
+    Value: clear display
+  - Id: 115
+    Value: show display
   AutoAllowAllSystemIntents: 0
   SystemCommands: 0
   SlotsForVoiceCommands: []

--- a/Assets/Scenes/final_scenes/Mission.unity
+++ b/Assets/Scenes/final_scenes/Mission.unity
@@ -1244,7 +1244,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 878749584}
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 9999990002}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1356,7 +1356,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1959078925}
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 9999990002}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1469,7 +1469,7 @@ RectTransform:
   m_LocalScale: {x: 0.001, y: 0.001, z: 0.001}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 9999990002}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1618,7 +1618,7 @@ RectTransform:
   m_LocalScale: {x: 0.001, y: 0.001, z: 0.001}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 9999990002}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -3222,7 +3222,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5000030011}
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 9999990002}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -3762,6 +3762,42 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9999990001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9999990002}
+  m_Layer: 0
+  m_Name: HUDRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9999990002
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9999990001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 850000011}
+  - {fileID: 850000021}
+  - {fileID: 850000031}
+  - {fileID: 850000041}
+  - {fileID: 5000030001}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -3774,14 +3810,10 @@ SceneRoots:
   - {fileID: 1350499924}
   - {fileID: 872049072}
   - {fileID: 224362098}
-  - {fileID: 850000011}
-  - {fileID: 850000021}
-  - {fileID: 850000031}
-  - {fileID: 850000041}
+  - {fileID: 9999990002}
   - {fileID: 1538358369}
   - {fileID: 1944448548}
   - {fileID: 7700000003}
   - {fileID: 5000010000}
   - {fileID: 5000020000}
-  - {fileID: 5000030001}
   - {fileID: 9200001}

--- a/Assets/UI-Scripts/HUDVisibilityBootstrap.cs
+++ b/Assets/UI-Scripts/HUDVisibilityBootstrap.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public static class HUDVisibilityBootstrap
+{
+    private const string StarterSceneName = "Starter";
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void Register()
+    {
+        SceneManager.sceneLoaded -= MaybeInstantiate;
+        SceneManager.sceneLoaded += MaybeInstantiate;
+        MaybeInstantiate(SceneManager.GetActiveScene(), LoadSceneMode.Single);
+    }
+
+    private static void MaybeInstantiate(Scene scene, LoadSceneMode mode)
+    {
+        if (HUDVisibilityController.Instance != null) return;
+        if (scene.name == StarterSceneName) return;
+        new GameObject(nameof(HUDVisibilityController)).AddComponent<HUDVisibilityController>();
+    }
+}

--- a/Assets/UI-Scripts/HUDVisibilityBootstrap.cs.meta
+++ b/Assets/UI-Scripts/HUDVisibilityBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c6f0a3d4b8e6a5cc5d9e6a7b8f0c3d4e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/UI-Scripts/HUDVisibilityController.cs
+++ b/Assets/UI-Scripts/HUDVisibilityController.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.XR.MagicLeap;
+
+public class HUDVisibilityController : MonoBehaviour
+{
+    public static HUDVisibilityController Instance { get; private set; }
+
+    private const string StarterSceneName = "Starter";
+    private const string HudRootName = "HUDRoot";
+    private const uint ClearDisplayIntentId = 114;
+    private const uint ShowDisplayIntentId = 115;
+
+    private GameObject _hudRoot;
+    private OpenPalmGestureDetector _detector;
+    private bool _listenersActive;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this) { Destroy(gameObject); return; }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
+        _detector = gameObject.AddComponent<OpenPalmGestureDetector>();
+        _detector.OnGestureTriggered.AddListener(Toggle);
+
+        SceneManager.sceneLoaded += OnSceneLoaded;
+        OnSceneLoaded(SceneManager.GetActiveScene(), LoadSceneMode.Single);
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this) Instance = null;
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+        SetListenersActive(false);
+    }
+
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        if (scene.name == StarterSceneName)
+        {
+            _hudRoot = null;
+            SetListenersActive(false);
+            return;
+        }
+
+        SetListenersActive(true);
+        _hudRoot = GameObject.Find(HudRootName);
+        if (_hudRoot == null)
+        {
+            Debug.LogWarning($"[HUDVisibility] '{HudRootName}' not found in scene '{scene.name}'. Toggle is a no-op until next scene load.");
+            return;
+        }
+        _hudRoot.SetActive(true);
+    }
+
+    public void Toggle()
+    {
+        if (_hudRoot != null) _hudRoot.SetActive(!_hudRoot.activeSelf);
+    }
+
+    public void ForceShow()
+    {
+        if (_hudRoot != null) _hudRoot.SetActive(true);
+    }
+
+    private void Hide() { if (_hudRoot != null) _hudRoot.SetActive(false); }
+    private void Show() { if (_hudRoot != null) _hudRoot.SetActive(true); }
+
+    private void SetListenersActive(bool active)
+    {
+        if (_listenersActive == active) return;
+        _listenersActive = active;
+        if (_detector != null) _detector.enabled = active;
+        if (active) MLVoice.OnVoiceEvent += OnMLVoice;
+        else MLVoice.OnVoiceEvent -= OnMLVoice;
+    }
+
+    private void OnMLVoice(in bool wasSuccessful, in MLVoice.IntentEvent ev)
+    {
+        if (!wasSuccessful) return;
+        if (ev.EventID == ClearDisplayIntentId) Hide();
+        else if (ev.EventID == ShowDisplayIntentId) Show();
+    }
+}

--- a/Assets/UI-Scripts/HUDVisibilityController.cs.meta
+++ b/Assets/UI-Scripts/HUDVisibilityController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b5e9f2c3a7d5f4bb4c8d5f6a7e9b2c3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/UI-Scripts/OpenPalmGestureDetector.cs
+++ b/Assets/UI-Scripts/OpenPalmGestureDetector.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.XR.Hands;
+
+public class OpenPalmGestureDetector : MonoBehaviour
+{
+    [SerializeField] private Camera userCamera;
+    [SerializeField] private float palmFacingDot = 0.7f;
+    [SerializeField] private float fingerExtendedDistance = 0.13f;
+    [SerializeField] private float holdSeconds = 0.3f;
+    [SerializeField] private float releaseSeconds = 0.5f;
+
+    public UnityEvent OnGestureTriggered;
+
+    private static readonly List<XRHandSubsystem> _cache = new List<XRHandSubsystem>();
+    private XRHandSubsystem _hands;
+
+    private enum State { Idle, Holding, Cooldown }
+    private State _state;
+    private float _timeInState;
+    private float _fingerExtendedSqr;
+
+    private void Awake()
+    {
+        _fingerExtendedSqr = fingerExtendedDistance * fingerExtendedDistance;
+        if (OnGestureTriggered == null) OnGestureTriggered = new UnityEvent();
+    }
+
+    private void Update()
+    {
+        if (_hands == null || !_hands.running)
+        {
+            SubsystemManager.GetSubsystems(_cache);
+            _hands = null;
+            for (int i = 0; i < _cache.Count; i++) if (_cache[i].running) { _hands = _cache[i]; break; }
+            if (_hands == null) return;
+        }
+
+        if (userCamera == null) userCamera = Camera.main;
+        if (userCamera == null) return;
+
+        bool active = IsOpenPalmFacingUser(_hands.leftHand) || IsOpenPalmFacingUser(_hands.rightHand);
+
+        switch (_state)
+        {
+            case State.Idle:
+                if (active) { _state = State.Holding; _timeInState = 0f; }
+                break;
+            case State.Holding:
+                if (!active) { _state = State.Idle; break; }
+                _timeInState += Time.deltaTime;
+                if (_timeInState >= holdSeconds)
+                {
+                    OnGestureTriggered?.Invoke();
+                    _state = State.Cooldown;
+                    _timeInState = 0f;
+                }
+                break;
+            case State.Cooldown:
+                if (active) { _timeInState = 0f; }
+                else
+                {
+                    _timeInState += Time.deltaTime;
+                    if (_timeInState >= releaseSeconds) _state = State.Idle;
+                }
+                break;
+        }
+    }
+
+    private bool IsOpenPalmFacingUser(XRHand hand)
+    {
+        if (!hand.isTracked) return false;
+        if (!TryPos(hand, XRHandJointID.Wrist, out Vector3 wrist)) return false;
+        if (!TryPos(hand, XRHandJointID.IndexMetacarpal, out Vector3 indexBase)) return false;
+        if (!TryPos(hand, XRHandJointID.LittleMetacarpal, out Vector3 littleBase)) return false;
+
+        Vector3 wristToIndex = indexBase - wrist;
+        Vector3 wristToLittle = littleBase - wrist;
+        Vector3 normal = hand.handedness == Handedness.Right
+            ? Vector3.Cross(wristToLittle, wristToIndex).normalized
+            : Vector3.Cross(wristToIndex, wristToLittle).normalized;
+
+        Vector3 palmCenter = (indexBase + littleBase + wrist) * (1f / 3f);
+        Vector3 toCamera = (userCamera.transform.position - palmCenter).normalized;
+        if (Vector3.Dot(normal, toCamera) < palmFacingDot) return false;
+
+        return Extended(hand, XRHandJointID.IndexTip, wrist)
+            && Extended(hand, XRHandJointID.MiddleTip, wrist)
+            && Extended(hand, XRHandJointID.RingTip, wrist)
+            && Extended(hand, XRHandJointID.LittleTip, wrist);
+    }
+
+    private bool Extended(XRHand hand, XRHandJointID tipId, Vector3 wrist)
+    {
+        return TryPos(hand, tipId, out Vector3 tip) && (tip - wrist).sqrMagnitude >= _fingerExtendedSqr;
+    }
+
+    private static bool TryPos(XRHand hand, XRHandJointID id, out Vector3 pos)
+    {
+        if (hand.GetJoint(id).TryGetPose(out Pose pose)) { pos = pose.position; return true; }
+        pos = default;
+        return false;
+    }
+}

--- a/Assets/UI-Scripts/OpenPalmGestureDetector.cs.meta
+++ b/Assets/UI-Scripts/OpenPalmGestureDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a4d8e1b2f6c4e3aa3b7c4e5f6d8a1b2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
OpenPalmGestureDetector uses XR Hands; either hand, 0.3s hold, 0.5s release. HUDVisibilityController is a DontDestroyOnLoad singleton that locates each scene's HUDRoot GameObject and toggles it via SetActive. Bootstrap auto-spawns the controller on the first non-Starter scene load.

Voice phrases "clear display" (114) and "show display" (115) registered with the existing MLVoiceIntentsConfiguration; the controller subscribes to MLVoice.OnVoiceEvent directly so the existing VoiceIntents plumbing is untouched.

Mission scene gets a HUDRoot with MinimapHud, CompassHud, IngressHud, EgressHud, and AIACanvas re-parented under it. WarningHUD stays outside as a safety-critical alert.