### PR TITLE
LTV: ERM-first priority, voice step advance, TSS polling fixes, dummy feeder

### DIFF
--- a/Assets/AIA/MLVoiceIntentsConfiguration.asset
+++ b/Assets/AIA/MLVoiceIntentsConfiguration.asset
@@ -40,6 +40,16 @@ MonoBehaviour:
     Value: end ingress
   - Id: 113
     Value: end ltv repair
+  - Id: 114
+    Value: clear display
+  - Id: 115
+    Value: show display
+  - Id: 116
+    Value: next step
+  - Id: 117
+    Value: show reference map
+  - Id: 118
+    Value: hide reference map
   AutoAllowAllSystemIntents: 0
   SystemCommands: 0
   SlotsForVoiceCommands: []

--- a/Assets/AIA/VoiceIntents.cs
+++ b/Assets/AIA/VoiceIntents.cs
@@ -21,6 +21,26 @@ public class VoiceIntents : MonoBehaviour
     // Configured in Assets/AIA/MLVoiceIntentsConfiguration.asset.
     private const uint SceneTransitionEventIdMin = 109;
     private const uint SceneTransitionEventIdMax = 113;
+    // MLVoice intent IDs for HUD visibility toggling. Fired as static events so
+    // per-scene HUDVisibilityController instances can subscribe without
+    // VoiceIntents needing a hard reference to them.
+    private const uint HudClearDisplayEventId = 114;
+    private const uint HudShowDisplayEventId = 115;
+    private const uint LtvNextStepEventId = 116;
+    // MLVoice intent IDs for the LTV reference map (LTV scene only).
+    private const uint LtvReferenceMapShowEventId = 117;
+    private const uint LtvReferenceMapHideEventId = 118;
+
+    /// <summary>Fires when the MLVoice "clear display" phrase is detected. Hides the HUD.</summary>
+    public static event Action HudClearDisplayRequested;
+    /// <summary>Fires when the MLVoice "show display" phrase is detected. Shows the HUD.</summary>
+    public static event Action HudShowDisplayRequested;
+    /// <summary>Fires when the MLVoice "next step" phrase is detected. Consumed by LTV scene only.</summary>
+    public static event Action LtvNextStepRequested;
+    /// <summary>Fires when the MLVoice "show reference map" phrase is detected. Consumed by LTV scene only.</summary>
+    public static event Action LtvReferenceMapShowRequested;
+    /// <summary>Fires when the MLVoice "hide reference map" phrase is detected. Consumed by LTV scene only.</summary>
+    public static event Action LtvReferenceMapHideRequested;
     // Bumped from 30s: gemma4:26b on Apple Silicon regularly takes 60-90s for first-token
     // latency on a cold model load (and 30-60s per generation while warm), so 30s caused
     // every Luna call to fail with "Luna request failed" before the orchestrator finished.
@@ -334,6 +354,31 @@ public class VoiceIntents : MonoBehaviour
             case AskLunaEventId:
                 Debug.Log("Hey Luna wake phrase detected");
                 StartAiaRecordingFromWakePhrase();
+                break;
+
+            case HudClearDisplayEventId:
+                Debug.Log("[HUD] 'clear display' phrase detected");
+                HudClearDisplayRequested?.Invoke();
+                break;
+
+            case HudShowDisplayEventId:
+                Debug.Log("[HUD] 'show display' phrase detected");
+                HudShowDisplayRequested?.Invoke();
+                break;
+
+            case LtvNextStepEventId:
+                Debug.Log("[LTV] 'next step' phrase detected");
+                LtvNextStepRequested?.Invoke();
+                break;
+
+            case LtvReferenceMapShowEventId:
+                Debug.Log("[LTVMap] 'show reference map' phrase detected");
+                LtvReferenceMapShowRequested?.Invoke();
+                break;
+
+            case LtvReferenceMapHideEventId:
+                Debug.Log("[LTVMap] 'hide reference map' phrase detected");
+                LtvReferenceMapHideRequested?.Invoke();
                 break;
 
             default:

--- a/Assets/LTV/DummyLtvFeeder.cs
+++ b/Assets/LTV/DummyLtvFeeder.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using TssApi;
+using UnityEngine;
+
+// Local test rig for the LTV priority queue and instruction flow. Enable this
+// GameObject to bypass TSS UDP, drive _ltv with hardcoded errors, and auto-flip
+// state to "resolved" once the service enters verification. Disable before
+// running against a real TSS server.
+public class DummyLtvFeeder : MonoBehaviour
+{
+    [SerializeField] private TssUnityApiService tssApi;
+    [SerializeField] private LtvInstructionService ltvService;
+    [Tooltip("Seconds to wait after verification begins before flipping the TSS state to 'resolved.'")]
+    [SerializeField] private float autoResolveDelay = 0.8f;
+    [Tooltip("Manual override key. Press while verifying to immediately resolve the current error at the dummy TSS.")]
+    [SerializeField] private KeyCode forceResolveKey = KeyCode.V;
+
+    private readonly List<DummyError> _errors = new List<DummyError>();
+    private string _autoResolvePending;
+
+    private void Awake()
+    {
+        BuildErrors();
+    }
+
+    private void OnEnable()
+    {
+        // Always prefer the persistent singleton. When LTV is entered via Mission,
+        // this scene's local TssUnityApiService Awake'd, called Destroy(this), and is
+        // flagged-but-not-yet-destroyed — the serialized ref still passes ==null, so
+        // we'd otherwise write dummy data into a doomed component while
+        // LtvInstructionService reads from Mission's singleton. Mismatch = headset
+        // shows zero errors. Editor (LTV opened directly) didn't hit this because
+        // LTV's local instance was the singleton.
+        TssUnityApiService persistent = TssUnityApiService.Instance;
+        if (persistent != null) tssApi = persistent;
+        else if (tssApi == null) tssApi = FindObjectOfType<TssUnityApiService>();
+        if (ltvService == null) ltvService = FindObjectOfType<LtvInstructionService>();
+
+        if (tssApi == null || ltvService == null)
+        {
+            Debug.LogError("[DummyLtv] Missing tssApi or ltvService reference. Disabling.", this);
+            enabled = false;
+            return;
+        }
+
+        tssApi.SkipUdpPolling = true;
+        PushSnapshot();
+        ltvService.InstructionUpdated += OnInstructionUpdated;
+        Debug.Log($"[DummyLtv] Active. {_errors.Count} dummy errors loaded; UDP polling paused. Press {forceResolveKey} during verify to force-resolve.", this);
+    }
+
+    private void OnDisable()
+    {
+        if (ltvService != null) ltvService.InstructionUpdated -= OnInstructionUpdated;
+        if (tssApi != null) tssApi.SkipUdpPolling = false;
+    }
+
+    private void Update()
+    {
+        if (!Input.GetKeyDown(forceResolveKey)) return;
+        if (ltvService != null && ltvService.IsVerifying && ltvService.CurrentError != null)
+        {
+            ResolveErrorByCode(ltvService.CurrentError.Code);
+        }
+    }
+
+    private void OnInstructionUpdated(Dictionary<string, object> snapshot)
+    {
+        if (snapshot == null) return;
+        bool verifying = snapshot.TryGetValue("verifying", out object v) && v is bool b && b;
+        string code = snapshot.TryGetValue("error_code", out object c) ? Convert.ToString(c) : null;
+        if (verifying && !string.IsNullOrEmpty(code) && _autoResolvePending != code)
+        {
+            _autoResolvePending = code;
+            StartCoroutine(AutoResolveAfter(autoResolveDelay, code));
+        }
+    }
+
+    private IEnumerator AutoResolveAfter(float delay, string code)
+    {
+        yield return new WaitForSeconds(delay);
+        if (_autoResolvePending == code) _autoResolvePending = null;
+        if (ltvService != null && ltvService.IsVerifying && ltvService.CurrentError != null && ltvService.CurrentError.Code == code)
+        {
+            ResolveErrorByCode(code);
+        }
+    }
+
+    private void ResolveErrorByCode(string code)
+    {
+        for (int i = 0; i < _errors.Count; i++)
+        {
+            if (_errors[i].Code == code)
+            {
+                _errors[i].NeedsResolved = false;
+                break;
+            }
+        }
+        PushSnapshot();
+        Debug.Log($"[DummyLtv] Resolved {code}; refreshed TSS snapshot.", this);
+    }
+
+    private void PushSnapshot()
+    {
+        List<object> procedures = new List<object>();
+        Dictionary<string, object> errorBools = new Dictionary<string, object>();
+        for (int i = 0; i < _errors.Count; i++)
+        {
+            DummyError e = _errors[i];
+            if (e.NeedsResolved)
+            {
+                List<object> steps = new List<object>(e.Procedures.Count);
+                for (int s = 0; s < e.Procedures.Count; s++) steps.Add(e.Procedures[s]);
+                procedures.Add(new Dictionary<string, object>
+                {
+                    { "code", e.Code },
+                    { "description", e.Description },
+                    { "needs_resolved", true },
+                    { "procedures", steps }
+                });
+            }
+            errorBools[e.ErrorKey] = e.NeedsResolved;
+        }
+
+        tssApi.OverrideLtvData(new Dictionary<string, object>
+        {
+            { "error_procedures", procedures },
+            { "errors", errorBools }
+        });
+    }
+
+    // 4800 ERM is listed LAST on purpose. The ERM-forced-first priority patch
+    // in LtvError must still pop it before 4968/4509/1969.
+    private void BuildErrors()
+    {
+        _errors.Clear();
+        _errors.Add(new DummyError("4509", "nav_system", "NAV Restart & Manual Return to Home", new List<string>
+        {
+            "1. Confirm NAV system error is active.",
+            "2. Initiate NAV restart from the control panel.",
+            "3. Wait for boot-complete indicator.",
+            "4. Verify NAV has returned to nominal."
+        }));
+        _errors.Add(new DummyError("1969", "fuse", "Backup Fuse Error", new List<string>
+        {
+            "1. Locate the backup fuse panel.",
+            "2. Inspect and replace the burnt fuse.",
+            "3. Reset the power switch."
+        }));
+        _errors.Add(new DummyError("4968", "power_subsystem_bus", "Subsystem Power Bus Error", new List<string>
+        {
+            "1. Check bus voltage on the main panel.",
+            "2. Engage the backup relay.",
+            "3. Verify downstream loads are powered."
+        }));
+        _errors.Add(new DummyError("4800", "recovery_mode", "Exit Recovery Mode (ERM)", new List<string>
+        {
+            "1. Confirm recovery-mode condition is present.",
+            "2. Stabilize attitude using forward thrusters.",
+            "3. Verify communications uplink is stable.",
+            "4. Announce ERM success."
+        }));
+    }
+
+    [Serializable]
+    private class DummyError
+    {
+        public string Code;
+        public string ErrorKey;
+        public string Description;
+        public List<string> Procedures;
+        public bool NeedsResolved;
+
+        public DummyError(string code, string errorKey, string description, List<string> procedures)
+        {
+            Code = code; ErrorKey = errorKey; Description = description; Procedures = procedures; NeedsResolved = true;
+        }
+    }
+}

--- a/Assets/LTV/DummyLtvFeeder.cs.meta
+++ b/Assets/LTV/DummyLtvFeeder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4f7a91e3d2c4f5d8a6e7b9c1d3e5f70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/LTV/LtvError.cs
+++ b/Assets/LTV/LtvError.cs
@@ -30,7 +30,8 @@ namespace LtvDiagnostics
 
             Criticality = ParseDigit(Code, 0);
             SubsystemId = ParseDigit(Code, 1);
-            Priority = Criticality * 10 + SubsystemId;
+            // ERM (4800 / recovery_mode) must run before any other error when active.
+            Priority = Code == "4800" ? int.MaxValue : Criticality * 10 + SubsystemId;
             Danger = ClassifyDanger(Criticality);
         }
 

--- a/Assets/LTV/LtvInstructionService.cs
+++ b/Assets/LTV/LtvInstructionService.cs
@@ -161,9 +161,13 @@ public class LtvInstructionService : MonoBehaviour
                 Debug.Log("[LTV] No error_procedures returned from TSS — likely UDP timeout or empty response.", this);
             }
 
+            // Cold-start with no TSS data: do NOT fire AllErrorsResolved. That message
+            // means "we finished work," not "TSS hasn't responded yet" — and firing it
+            // here latches the HUD onto "All LTV errors resolved" until ErrorChanged
+            // fires later. RefreshLoop will queue real errors as they arrive; PopNextError
+            // will fire AllErrorsResolved once we've actually had work to finish.
             diagnosisActive = false;
             DiagnosisStarted?.Invoke(0);
-            AllErrorsResolved?.Invoke();
             EmitSnapshot();
             return;
         }
@@ -553,6 +557,9 @@ public class LtvInstructionService : MonoBehaviour
         }
 
         int addedCount = 0;
+        int filteredNoNeedResolve = 0;
+        int filteredEmptyProcedures = 0;
+        int filteredAlreadyQueued = 0;
         for (int i = 0; i < errorProcedures.Count; i++)
         {
             Dictionary<string, object> raw = errorProcedures[i];
@@ -562,15 +569,13 @@ public class LtvInstructionService : MonoBehaviour
             }
 
             LtvError error = ParseError(raw);
-            if (error == null || !error.NeedsResolved || error.Procedures.Count == 0)
+            if (error == null)
             {
                 continue;
             }
-
-            if (queuedCodes.Contains(error.Code))
-            {
-                continue;
-            }
+            if (!error.NeedsResolved) { filteredNoNeedResolve++; continue; }
+            if (error.Procedures.Count == 0) { filteredEmptyProcedures++; continue; }
+            if (queuedCodes.Contains(error.Code)) { filteredAlreadyQueued++; continue; }
 
             errorHeap.Insert(error);
             queuedCodes.Add(error.Code);
@@ -584,6 +589,25 @@ public class LtvInstructionService : MonoBehaviour
                     this
                 );
             }
+        }
+
+        // Surface the silent-filter case: TSS returned entries but none made it into the
+        // heap, leaving the HUD stuck on "no errors." Dumps the first raw entry's keys so
+        // a field-name mismatch (needs_resolution vs needs_resolved, steps vs procedures)
+        // shows up in the console instead of as an invisible no-op.
+        if (enableDebugLogs && addedCount == 0 && errorProcedures.Count > 0
+            && filteredAlreadyQueued < errorProcedures.Count)
+        {
+            string firstKeys = errorProcedures[0] != null
+                ? string.Join(",", errorProcedures[0].Keys)
+                : "(null)";
+            Debug.LogWarning(
+                $"[LTV] Refresh saw {errorProcedures.Count} TSS entries but queued 0. " +
+                $"filtered needs_resolved=false:{filteredNoNeedResolve}, " +
+                $"empty_procedures:{filteredEmptyProcedures}, already_queued:{filteredAlreadyQueued}. " +
+                $"First entry keys: [{firstKeys}]",
+                this
+            );
         }
 
         return addedCount;

--- a/Assets/Scenes/final_scenes/LTV.unity
+++ b/Assets/Scenes/final_scenes/LTV.unity
@@ -571,6 +571,7 @@ GameObject:
   - component: {fileID: 476612523}
   - component: {fileID: 476612524}
   - component: {fileID: 476612526}
+  - component: {fileID: 476612529}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -727,6 +728,19 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 4294967295
   m_RaycastTriggerInteraction: 1
+--- !u!114 &476612529
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476612518}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a7c39e0b4f8d2c5a8b3f6e9d1c2a4b7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hudController: {fileID: 476612523}
 --- !u!1 &760095027
 GameObject:
   m_ObjectHideFlags: 0
@@ -1091,14 +1105,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: VitalsButtonCanvas
       objectReference: {fileID: 0}
+    - target: {fileID: 7699461129031171122, guid: f520c6b2f608a43c2864a7b861579e59, type: 3}
+      propertyPath: healthCanvas
+      value: 
+      objectReference: {fileID: 467610814}
     - target: {fileID: 8374780147099731469, guid: f520c6b2f608a43c2864a7b861579e59, type: 3}
       propertyPath: m_Camera
       value: 
       objectReference: {fileID: 108399580}
-    - target: {fileID: 7699461129031171122, guid: f520c6b2f608a43c2864a7b861579e59, type: 3}
-      propertyPath: healthCanvas
-      value:
-      objectReference: {fileID: 467610814}
     - target: {fileID: 8825100611093449677, guid: f520c6b2f608a43c2864a7b861579e59, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -1368,7 +1382,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3177212473821427495, guid: d4ffbdc4a993a44cda05f2eab6317851, type: 3}
       propertyPath: tssHost
-      value: 10.207.89.182
+      value: 192.168.22.44
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1530,6 +1544,101 @@ MonoBehaviour:
   errorListRefreshSeconds: 1
   maxRetries: 3
   enableDebugLogs: 1
+--- !u!1 &1900000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1900000002}
+  - component: {fileID: 1900000003}
+  m_Layer: 0
+  m_Name: LTVReferenceMapController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1900000002
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1900000001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1900000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1900000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ff64a5b37ad476ead48cd3c2239a013, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mapSprite: {fileID: 21300000, guid: 6b1a1c0aed2e43c29c07fccb6c5c4944, type: 3}
+  worldSize: {x: 0.5, y: 0.4}
+  spawnDistanceMeters: 1
+--- !u!1 &1900000010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1900000011}
+  - component: {fileID: 1900000012}
+  m_Layer: 0
+  m_Name: DummyLtvFeeder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1900000011
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1900000010}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1900000012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1900000010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b4f7a91e3d2c4f5d8a6e7b9c1d3e5f70, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tssApi: {fileID: 1644719096}
+  ltvService: {fileID: 1773227994}
+  autoResolveDelay: 0.8
+  forceResolveKey: 118
 --- !u!1 &1936135107
 GameObject:
   m_ObjectHideFlags: 0
@@ -1638,3 +1747,5 @@ SceneRoots:
   - {fileID: 467610813}
   - {fileID: 1419207192}
   - {fileID: 1644719095}
+  - {fileID: 1900000002}
+  - {fileID: 1900000011}

--- a/Assets/TSS-API/TssUnityApiService.cs
+++ b/Assets/TSS-API/TssUnityApiService.cs
@@ -28,6 +28,11 @@ namespace TssApi
         [Header("Procedure Data")]
         [SerializeField] private TextAsset ltvProceduresJson;
 
+        [Header("Testing")]
+        [Tooltip("When true, the poll loop stops issuing UDP requests so a dummy feeder can drive _ltv directly via OverrideLtvData. Don't ship this on.")]
+        [SerializeField] private bool skipUdpPolling = false;
+        public bool SkipUdpPolling { get => skipUdpPolling; set => skipUdpPolling = value; }
+
         public event Action<Dictionary<string, object>> EvaUpdated;
 
         public static TssUnityApiService Instance { get; private set; }
@@ -558,11 +563,25 @@ namespace TssApi
             return false;
         }
 
+        public void OverrideLtvData(Dictionary<string, object> data)
+        {
+            if (data == null) return;
+            MergeIntoLtv(data);
+            _sourceOnline = true;
+            _lastUpdatedUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        }
+
         private IEnumerator PollLoop()
         {
             WaitForSeconds wait = new WaitForSeconds(Mathf.Max(0.05f, pollIntervalSeconds));
             while (true)
             {
+                if (skipUdpPolling)
+                {
+                    yield return wait;
+                    continue;
+                }
+
                 Dictionary<string, object> evaRaw = _udp != null ? _udp.RequestJson(UdpGetEva) : null;
                 Dictionary<string, object> ltvRaw = _udp != null ? _udp.RequestJson(UdpGetLtv) : null;
                 Dictionary<string, object> ltvErrorsRaw = _udp != null ? _udp.RequestJson(UdpGetLtvErrors) : null;
@@ -573,14 +592,17 @@ namespace TssApi
                     EvaUpdated?.Invoke(GetEva());
                 }
 
+                // Merge each feed in place. Wholesale-replacing _ltv with ltvRaw would
+                // erase error_procedures (which only ships in the LtvErrors feed) any
+                // time UdpGetLtvErrors times out on a poll while UdpGetLtv succeeds.
                 if (ltvRaw != null)
                 {
-                    _ltv = ltvRaw;
+                    MergeIntoLtv(ltvRaw);
                 }
 
                 if (ltvErrorsRaw != null)
                 {
-                    MergeLtvErrors(ltvErrorsRaw);
+                    MergeIntoLtv(ltvErrorsRaw);
                 }
 
                 bool newOnline = evaRaw != null && ltvRaw != null;
@@ -662,14 +684,14 @@ namespace TssApi
             _procedures = parsed as Dictionary<string, object> ?? new Dictionary<string, object>();
         }
 
-        private void MergeLtvErrors(Dictionary<string, object> ltvErrorsRaw)
+        private void MergeIntoLtv(Dictionary<string, object> source)
         {
             if (_ltv == null)
             {
                 _ltv = new Dictionary<string, object>();
             }
 
-            foreach (KeyValuePair<string, object> kvp in ltvErrorsRaw)
+            foreach (KeyValuePair<string, object> kvp in source)
             {
                 _ltv[kvp.Key] = kvp.Value;
             }

--- a/Assets/UI-Scripts/LTVVoiceStepAdvance.cs
+++ b/Assets/UI-Scripts/LTVVoiceStepAdvance.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+// LTV-only: subscribes to the "next step" MLVoice phrase via VoiceIntents and
+// invokes the checkmark button's existing onClick path. No second recognizer.
+public class LTVVoiceStepAdvance : MonoBehaviour
+{
+    [SerializeField] private LtvHudController hudController;
+
+    private void OnEnable()
+    {
+        VoiceIntents.LtvNextStepRequested += HandleNextStep;
+    }
+
+    private void OnDisable()
+    {
+        VoiceIntents.LtvNextStepRequested -= HandleNextStep;
+    }
+
+    private void HandleNextStep()
+    {
+        if (hudController == null)
+        {
+            Debug.LogWarning("[LTVVoiceStepAdvance] hudController not assigned; ignoring 'next step' voice phrase.", this);
+            return;
+        }
+
+        hudController.InvokeCheckmark("voice");
+    }
+}

--- a/Assets/UI-Scripts/LTVVoiceStepAdvance.cs.meta
+++ b/Assets/UI-Scripts/LTVVoiceStepAdvance.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7c39e0b4f8d2c5a8b3f6e9d1c2a4b7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- **ERM (4800) always runs first.** `LtvError` assigns code `4800` priority `int.MaxValue`, so the max-heap pops it before any other queued error regardless of criticality digits. Other codes still use `criticality*10 + subsystem`.
- **"next step" voice command for LTV.** New MLVoice intent id 116 (`Assets/AIA/MLVoiceIntentsConfiguration.asset`), wired through a `LtvNextStepRequested` static event on `VoiceIntents`. New `LTVVoiceStepAdvance` MonoBehaviour subscribes per-scene and invokes `LtvHudController.InvokeCheckmark("voice")` — identical effect to clicking the checkmark. Component placed on the existing Canvas GameObject in `LTV.unity`.
- **TSS polling race fix.** `PollLoop` now merges `ltvRaw` into `_ltv` instead of wholesale-replacing it. Without this, an intermittent `UdpGetLtvErrors` timeout would erase `error_procedures` from the previous poll and the HUD would briefly believe everything was resolved.
- **Cold-start no longer fires `AllErrorsResolved`.** `StartDiagnosisFromTss` used to fire it when the first TSS poll returned empty, latching the HUD onto "All LTV errors resolved" before TSS had a chance to respond. Now we only emit `DiagnosisStarted(0)` and let `RefreshLoop` discover errors as they arrive.
- **Refresh-filter visibility.** When `RefreshFromTss` sees TSS entries but queues zero (e.g., `needs_resolved=false` or empty `procedures[]`), it now logs counts + the first entry's keys. Helps next debug session pinpoint field-name mismatches instead of silent no-ops.
- **`DummyLtvFeeder` + `SkipUdpPolling`/`OverrideLtvData` hooks.** New `TssUnityApiService` API lets a feeder drive `_ltv` directly while the UDP coroutine sleeps. `DummyLtvFeeder` ships 4 hardcoded errors (NAV/Fuse/Power/ERM), auto-flips state to resolved when the service enters verification, and uses `TssUnityApiService.Instance` at `OnEnable` time to dodge the Mission→LTV singleton-destruction race that previously caused dummy writes to land on a doomed scene-local component. **GameObject is inactive by default** in `LTV.unity` — enable for local testing, leave off for real TSS.

## Test plan

- [ ] Open `LTV.unity` in editor, enable the `DummyLtvFeeder` GameObject, press Play. Expect: ERM (4800) pops first (proves ERM-priority patch), step through the 4 ERM instructions, auto-resolve fires within ~0.8s of entering verify, NAV (4509) → Power Bus (4968) → Fuse (1969) → "All LTV errors resolved."
- [ ] Press **V** during verification — confirms manual force-resolve override works.
- [ ] Disable `DummyLtvFeeder`, press Play with real TSS reachable. Expect: original UDP-driven flow, no dummy interference.
- [ ] Build to Magic Leap 2, launch via Mission → "ltv repair" voice command. Expect: real TSS flow works (no singleton mismatch).
- [ ] Say "next step" while on an LTV procedure step. Expect: advance equivalent to clicking the checkmark button.