### PR TITLE
Revert Astrowebdeving Vosk changes — restore last working AIA

### DIFF
--- a/Assets/AIA/AIAVoskInputController.cs
+++ b/Assets/AIA/AIAVoskInputController.cs
@@ -157,20 +157,13 @@ public class AIAVoskInputController : MonoBehaviour
     [SerializeField] private string voskModelPath = DefaultVoskModelPath;
     [SerializeField] private int maxAlternatives = 1;
     [SerializeField] private float initializationTimeoutSeconds = 120f;
-    [SerializeField] private float silenceStopSeconds = 2f;
+    [SerializeField] private float silenceStopSeconds = 1.5f;
     [SerializeField, Range(0f, 1f), Tooltip(
         "Volume threshold (0–1) above which a sample is treated as speech. " +
         "The Magic Leap 2 headset mic typically peaks around 0.02–0.04 for normal " +
-        "indoor speech; RMS/noise-floor gates also apply so brief spikes are ignored.")]
-    private float voiceDetectionThreshold = 0.012f;
-    [SerializeField, Range(0f, 1f), Tooltip("Minimum RMS frame volume required before Vosk treats a frame as speech.")]
-    private float voiceDetectionRmsThreshold = 0.0025f;
-    [SerializeField, Range(1f, 10f), Tooltip("Speech must be this many times louder than the learned room-noise RMS floor.")]
-    private float voiceDetectionNoiseMultiplier = 2.2f;
-    [SerializeField, Range(0f, 0.5f), Tooltip("Speech-like audio must persist this long before recording opens.")]
-    private float speechStartDebounceSeconds = 0.12f;
-    [SerializeField, Range(0f, 0.5f), Tooltip("Quiet audio must persist this long before the silence timer can close the recording.")]
-    private float speechEndDebounceSeconds = 0.18f;
+        "indoor speech; the original Picovoice default of 0.05 was too high and " +
+        "caused Vosk to receive zero audio frames.")]
+    private float voiceDetectionThreshold = 0.01f;
     [SerializeField, Tooltip(
         "Hard cap on recording length (seconds). If the user starts a recording and " +
         "the VAD never trips (e.g. mic is muted), recording is force-stopped after this many seconds " +
@@ -182,11 +175,7 @@ public class AIAVoskInputController : MonoBehaviour
 
     private Coroutine maxRecordingTimeoutCoroutine;
     private Coroutine audioLevelMonitorCoroutine;
-    private Coroutine partialTranscriptTimeoutCoroutine;
     private float peakAmplitudeThisSession;
-    private float rmsAmplitudeThisSession;
-    private float lastPartialTranscriptTime = -1f;
-    private string lastPartialTranscriptText = string.Empty;
 
     private readonly MLPermissions.Callbacks permissionCallbacks = new MLPermissions.Callbacks();
     private bool hasRecordPermission;
@@ -401,10 +390,6 @@ public class AIAVoskInputController : MonoBehaviour
         if (voiceProcessor != null)
         {
             voiceProcessor.MinimumSpeakingSampleValue = voiceDetectionThreshold;
-            voiceProcessor.MinimumSpeakingRmsValue = voiceDetectionRmsThreshold;
-            voiceProcessor.NoiseFloorMultiplier = voiceDetectionNoiseMultiplier;
-            voiceProcessor.SpeechStartDebounceSeconds = speechStartDebounceSeconds;
-            voiceProcessor.SpeechEndDebounceSeconds = speechEndDebounceSeconds;
         }
         voskSpeechToText.OnStatusUpdated -= HandleVoskStatusUpdated;
         voskSpeechToText.OnTranscriptionResult -= HandleTranscriptionResult;
@@ -508,7 +493,8 @@ public class AIAVoskInputController : MonoBehaviour
 
         try
         {
-            ResetRecordingSessionState();
+            _routedSceneVoiceThisSession = false;
+            peakAmplitudeThisSession = 0f;
 
             if (voiceIntents != null)
             {
@@ -561,10 +547,6 @@ public class AIAVoskInputController : MonoBehaviour
         {
             audioLevelMonitorCoroutine = StartCoroutine(MonitorAudioLevels());
         }
-        if (silenceStopSeconds > 0f)
-        {
-            partialTranscriptTimeoutCoroutine = StartCoroutine(PartialTranscriptWatchdog());
-        }
     }
 
     private void CancelRecordingTimeouts()
@@ -579,11 +561,6 @@ public class AIAVoskInputController : MonoBehaviour
             StopCoroutine(audioLevelMonitorCoroutine);
             audioLevelMonitorCoroutine = null;
         }
-        if (partialTranscriptTimeoutCoroutine != null)
-        {
-            StopCoroutine(partialTranscriptTimeoutCoroutine);
-            partialTranscriptTimeoutCoroutine = null;
-        }
     }
 
     private IEnumerator MaxRecordingWatchdog(float seconds)
@@ -592,8 +569,7 @@ public class AIAVoskInputController : MonoBehaviour
         if (voiceProcessor != null && voiceProcessor.IsRecording)
         {
             Debug.LogWarning($"[Vosk] Max-recording watchdog fired after {seconds:F1}s — force-stopping. " +
-                             $"Peak/RMS mic amplitude this session: {peakAmplitudeThisSession:F4}/{rmsAmplitudeThisSession:F4} " +
-                             $"(thresholds {voiceDetectionThreshold:F4}/{voiceDetectionRmsThreshold:F4}).");
+                             $"Peak mic amplitude this session: {peakAmplitudeThisSession:F4} (threshold {voiceDetectionThreshold:F4}).");
             StopRecording();
         }
     }
@@ -606,41 +582,17 @@ public class AIAVoskInputController : MonoBehaviour
         while (voiceProcessor != null && voiceProcessor.IsRecording)
         {
             float level = voiceProcessor.LastFrameMaxAmplitude;
-            float rms = voiceProcessor.LastFrameRmsAmplitude;
             if (level > peakAmplitudeThisSession) peakAmplitudeThisSession = level;
-            if (rms > rmsAmplitudeThisSession) rmsAmplitudeThisSession = rms;
 
             if (Time.unscaledTime - lastLogTime >= 1f)
             {
-                Debug.Log($"[Vosk] mic level peak/rms = {level:F4}/{rms:F4}, " +
-                          $"session peak/rms = {peakAmplitudeThisSession:F4}/{rmsAmplitudeThisSession:F4}, " +
-                          $"threshold peak/rms = {voiceDetectionThreshold:F4}/{voiceProcessor.CurrentRmsSpeechThreshold:F4}, " +
-                          $"noise floor rms = {voiceProcessor.EstimatedNoiseFloorRms:F4}.");
+                Debug.Log($"[Vosk] mic level (peak this frame) = {level:F4}, " +
+                          $"session peak = {peakAmplitudeThisSession:F4}, threshold = {voiceDetectionThreshold:F4}.");
                 lastLogTime = Time.unscaledTime;
             }
             yield return wait;
         }
         audioLevelMonitorCoroutine = null;
-    }
-
-    private IEnumerator PartialTranscriptWatchdog()
-    {
-        WaitForSeconds wait = new WaitForSeconds(0.1f);
-        while (voiceProcessor != null && voiceProcessor.IsRecording)
-        {
-            if (lastPartialTranscriptTime > 0f &&
-                Time.unscaledTime - lastPartialTranscriptTime >= silenceStopSeconds)
-            {
-                Debug.Log($"[Vosk] Partial transcript idle for {silenceStopSeconds:F1}s. Stopping recording.");
-                partialTranscriptTimeoutCoroutine = null;
-                StopRecording();
-                yield break;
-            }
-
-            yield return wait;
-        }
-
-        partialTranscriptTimeoutCoroutine = null;
     }
 
     private void HandleVoskStatusUpdated(string status)
@@ -652,8 +604,6 @@ public class AIAVoskInputController : MonoBehaviour
             isRecording = voiceProcessor != null && voiceProcessor.IsRecording;
             if (isRecording)
             {
-                ResetRecordingSessionState();
-                BeginRecordingTimeouts();
                 if (voiceIntents != null)
                 {
                     voiceIntents.BeginRecordingTranscript();
@@ -693,12 +643,11 @@ public class AIAVoskInputController : MonoBehaviour
             string transcript = result.Phrases[0]?.Text?.Trim();
             if (string.IsNullOrWhiteSpace(transcript))
             {
-                bool micWasHeard = peakAmplitudeThisSession >= voiceDetectionThreshold
-                                   || rmsAmplitudeThisSession >= voiceDetectionRmsThreshold;
+                bool micWasHeard = peakAmplitudeThisSession >= voiceDetectionThreshold;
                 Debug.LogWarning(
                     $"[Vosk] Empty transcription result: {rawJson}. " +
-                    $"Peak/RMS mic amplitude this session = {peakAmplitudeThisSession:F4}/{rmsAmplitudeThisSession:F4} " +
-                    $"(thresholds {voiceDetectionThreshold:F4}/{voiceDetectionRmsThreshold:F4}). " +
+                    $"Peak mic amplitude this session = {peakAmplitudeThisSession:F4} " +
+                    $"(threshold {voiceDetectionThreshold:F4}). " +
                     (micWasHeard
                         ? "Mic was audible but Vosk did not recognize any words — try speaking closer to the headset or check the model is loaded."
                         : "Mic NEVER crossed the VAD threshold — check that the headset microphone is enabled, unmuted, and that no other process (e.g. MLVoice/Luna) is holding it. " +
@@ -764,18 +713,15 @@ public class AIAVoskInputController : MonoBehaviour
             }
 
             partialTranscript = NormalizeDomainTranscript(partialTranscript);
-            if (!string.Equals(partialTranscript, lastPartialTranscriptText, StringComparison.Ordinal))
-            {
-                lastPartialTranscriptText = partialTranscript;
-                lastPartialTranscriptTime = Time.unscaledTime;
-            }
 
             if (voiceIntents != null)
             {
                 voiceIntents.UpdateRecordingTranscript(partialTranscript);
 
-                // Route scene transitions off the live partial stream so commands fire
-                // as soon as Vosk has enough audio, without waiting for finalization.
+                // VoiceProcessor's silence detection on ML2 doesn't reliably fire, so the
+                // recording stays open and the final transcript never emits. Route scene
+                // transitions off the live partial stream instead — fires the moment Vosk
+                // has heard enough audio to recognize a configured command.
                 if (!_routedSceneVoiceThisSession &&
                     voiceIntents.TryRouteSceneVoiceCommand(partialTranscript))
                 {
@@ -864,15 +810,6 @@ public class AIAVoskInputController : MonoBehaviour
         }
 
         Debug.LogWarning($"[Vosk] Could not display status because no AIA text box was found. Status: {text}");
-    }
-
-    private void ResetRecordingSessionState()
-    {
-        _routedSceneVoiceThisSession = false;
-        peakAmplitudeThisSession = 0f;
-        rmsAmplitudeThisSession = 0f;
-        lastPartialTranscriptTime = -1f;
-        lastPartialTranscriptText = string.Empty;
     }
 
     private string GetSafeVoskModelPath()

--- a/Assets/AIA/AIAVoskInputController.cs
+++ b/Assets/AIA/AIAVoskInputController.cs
@@ -157,20 +157,20 @@ public class AIAVoskInputController : MonoBehaviour
     [SerializeField] private string voskModelPath = DefaultVoskModelPath;
     [SerializeField] private int maxAlternatives = 1;
     [SerializeField] private float initializationTimeoutSeconds = 120f;
-    [SerializeField] private float silenceStopSeconds = 1.8f;
+    [SerializeField] private float silenceStopSeconds = 2f;
     [SerializeField, Range(0f, 1f), Tooltip(
         "Volume threshold (0–1) above which a sample is treated as speech. " +
         "The Magic Leap 2 headset mic typically peaks around 0.02–0.04 for normal " +
         "indoor speech; RMS/noise-floor gates also apply so brief spikes are ignored.")]
-    private float voiceDetectionThreshold = 0.01f;
+    private float voiceDetectionThreshold = 0.012f;
     [SerializeField, Range(0f, 1f), Tooltip("Minimum RMS frame volume required before Vosk treats a frame as speech.")]
-    private float voiceDetectionRmsThreshold = 0.002f;
+    private float voiceDetectionRmsThreshold = 0.0025f;
     [SerializeField, Range(1f, 10f), Tooltip("Speech must be this many times louder than the learned room-noise RMS floor.")]
-    private float voiceDetectionNoiseMultiplier = 2.0f;
+    private float voiceDetectionNoiseMultiplier = 2.2f;
     [SerializeField, Range(0f, 0.5f), Tooltip("Speech-like audio must persist this long before recording opens.")]
-    private float speechStartDebounceSeconds = 0.1f;
+    private float speechStartDebounceSeconds = 0.12f;
     [SerializeField, Range(0f, 0.5f), Tooltip("Quiet audio must persist this long before the silence timer can close the recording.")]
-    private float speechEndDebounceSeconds = 0.12f;
+    private float speechEndDebounceSeconds = 0.18f;
     [SerializeField, Tooltip(
         "Hard cap on recording length (seconds). If the user starts a recording and " +
         "the VAD never trips (e.g. mic is muted), recording is force-stopped after this many seconds " +
@@ -516,7 +516,7 @@ public class AIAVoskInputController : MonoBehaviour
             }
             else
             {
-                UpdateStatus("Recording your question... Pause briefly or tap Stop.");
+                UpdateStatus("Recording your question... Pause for 2 seconds or tap Stop.");
             }
 
             voskSpeechToText.ToggleRecording();
@@ -660,7 +660,7 @@ public class AIAVoskInputController : MonoBehaviour
                 }
                 else
                 {
-                    UpdateStatus("Recording your question... Pause briefly or tap Stop.");
+                    UpdateStatus("Recording your question... Pause for 2 seconds or tap Stop.");
                 }
             }
             StopInitializationTimeout();

--- a/Assets/AIA/AIAVoskInputController.cs
+++ b/Assets/AIA/AIAVoskInputController.cs
@@ -157,8 +157,6 @@ public class AIAVoskInputController : MonoBehaviour
     [SerializeField] private string voskModelPath = DefaultVoskModelPath;
     [SerializeField] private int maxAlternatives = 1;
     [SerializeField] private float initializationTimeoutSeconds = 120f;
-    [SerializeField] private bool preloadVoskOnStart = true;
-    [SerializeField, Range(0f, 1f)] private float wakePhraseHandoffDelaySeconds = 0.35f;
     [SerializeField] private float silenceStopSeconds = 1.8f;
     [SerializeField, Range(0f, 1f), Tooltip(
         "Volume threshold (0–1) above which a sample is treated as speech. " +
@@ -200,9 +198,6 @@ public class AIAVoskInputController : MonoBehaviour
     // so subsequent partials don't double-trigger before recording stops.
     private bool _routedSceneVoiceThisSession;
     private Coroutine initializationTimeoutCoroutine;
-    private Coroutine wakePhraseRecordingCoroutine;
-    private bool pendingWakeStartAfterPermission;
-    private bool suppressVoskStatusUpdates;
 
     private void Awake()
     {
@@ -218,10 +213,6 @@ public class AIAVoskInputController : MonoBehaviour
         ConfigureVosk();
 
         hasRecordPermission = MLPermissions.CheckPermission(MLPermission.RecordAudio).IsOk;
-        if (hasRecordPermission)
-        {
-            TryPreloadVosk();
-        }
         RefreshButtonVisuals();
     }
 
@@ -248,12 +239,6 @@ public class AIAVoskInputController : MonoBehaviour
         if (voiceProcessor != null && voiceProcessor.IsRecording)
         {
             voiceProcessor.StopRecording();
-        }
-
-        if (wakePhraseRecordingCoroutine != null)
-        {
-            StopCoroutine(wakePhraseRecordingCoroutine);
-            wakePhraseRecordingCoroutine = null;
         }
     }
 
@@ -301,53 +286,40 @@ public class AIAVoskInputController : MonoBehaviour
     /// </summary>
     public void StartRecordingFromVoiceIntent()
     {
-        if (!EnsureMicrophonePermission(fromWakePhrase: true))
+        if (!EnsureMicrophonePermission())
         {
             return;
         }
 
-        if (wakePhraseRecordingCoroutine != null)
+        if (isVoskInitializing)
         {
-            StopCoroutine(wakePhraseRecordingCoroutine);
+            UpdateStatus("Vosk is still initializing...");
+            return;
         }
 
-        wakePhraseRecordingCoroutine = StartCoroutine(StartRecordingAfterWakePhraseHandoff());
-    }
-
-    private IEnumerator StartRecordingAfterWakePhraseHandoff()
-    {
         if (voiceProcessor != null && voiceProcessor.IsRecording)
         {
             StopRecording();
-            yield return null;
+            StartCoroutine(RestartRecordingNextFrame());
+            return;
         }
 
         if (!isVoskInitialized)
         {
-            if (!isVoskInitializing)
-            {
-                InitializeVosk(startRecordingWhenReady: false);
-            }
-
-            while (isVoskInitializing)
-            {
-                yield return null;
-            }
-
-            if (!isVoskInitialized)
-            {
-                wakePhraseRecordingCoroutine = null;
-                yield break;
-            }
-        }
-
-        if (wakePhraseHandoffDelaySeconds > 0f)
-        {
-            yield return new WaitForSeconds(wakePhraseHandoffDelaySeconds);
+            InitializeVosk(startRecordingWhenReady: true);
+            return;
         }
 
         StartRecording();
-        wakePhraseRecordingCoroutine = null;
+    }
+
+    private IEnumerator RestartRecordingNextFrame()
+    {
+        yield return null;
+        if (isVoskInitialized)
+        {
+            StartRecording();
+        }
     }
 
     private void TryResolveReferences()
@@ -448,7 +420,7 @@ public class AIAVoskInputController : MonoBehaviour
         }
     }
 
-    private bool EnsureMicrophonePermission(bool fromWakePhrase = false)
+    private bool EnsureMicrophonePermission()
     {
         if (hasRecordPermission || MLPermissions.CheckPermission(MLPermission.RecordAudio).IsOk)
         {
@@ -456,8 +428,7 @@ public class AIAVoskInputController : MonoBehaviour
             return true;
         }
 
-        pendingStartAfterPermission = !fromWakePhrase;
-        pendingWakeStartAfterPermission = fromWakePhrase;
+        pendingStartAfterPermission = true;
         UpdateStatus("Microphone permission required for Vosk recording.");
         MLPermissions.RequestPermission(MLPermission.RecordAudio, permissionCallbacks);
         return false;
@@ -472,16 +443,8 @@ public class AIAVoskInputController : MonoBehaviour
 
         hasRecordPermission = true;
 
-        if (pendingWakeStartAfterPermission)
-        {
-            pendingWakeStartAfterPermission = false;
-            StartRecordingFromVoiceIntent();
-            return;
-        }
-
         if (!pendingStartAfterPermission)
         {
-            TryPreloadVosk();
             return;
         }
 
@@ -497,40 +460,22 @@ public class AIAVoskInputController : MonoBehaviour
         }
 
         pendingStartAfterPermission = false;
-        pendingWakeStartAfterPermission = false;
         UpdateStatus("Microphone permission denied.");
         RefreshButtonVisuals();
     }
 
-    private void TryPreloadVosk()
-    {
-        if (!preloadVoskOnStart || isVoskInitialized || isVoskInitializing || voskSpeechToText == null)
-        {
-            return;
-        }
-
-        InitializeVosk(startRecordingWhenReady: false, showStatus: false);
-    }
-
-    private void InitializeVosk(bool startRecordingWhenReady, bool showStatus = true)
+    private void InitializeVosk(bool startRecordingWhenReady)
     {
         if (voskSpeechToText == null)
         {
-            if (showStatus)
-            {
-                UpdateStatus("Vosk speech recognizer is missing.");
-            }
+            UpdateStatus("Vosk speech recognizer is missing.");
             return;
         }
 
         try
         {
             isVoskInitializing = true;
-            suppressVoskStatusUpdates = !showStatus;
-            if (showStatus)
-            {
-                UpdateStatus("Loading Vosk model...");
-            }
+            UpdateStatus("Loading Vosk model...");
             RefreshButtonVisuals();
 
             string safeModelPath = GetSafeVoskModelPath();
@@ -547,12 +492,8 @@ public class AIAVoskInputController : MonoBehaviour
         {
             Debug.LogError($"[Vosk] Failed to initialize: {exception}");
             isVoskInitializing = false;
-            suppressVoskStatusUpdates = false;
             StopInitializationTimeout();
-            if (showStatus)
-            {
-                UpdateStatus("Vosk initialization failed.");
-            }
+            UpdateStatus("Vosk initialization failed.");
             RefreshButtonVisuals();
         }
     }
@@ -708,7 +649,6 @@ public class AIAVoskInputController : MonoBehaviour
         {
             isVoskInitializing = false;
             isVoskInitialized = true;
-            suppressVoskStatusUpdates = false;
             isRecording = voiceProcessor != null && voiceProcessor.IsRecording;
             if (isRecording)
             {
@@ -725,19 +665,9 @@ public class AIAVoskInputController : MonoBehaviour
             }
             StopInitializationTimeout();
         }
-        else if (IsVoskFailureStatus(status))
-        {
-            isVoskInitializing = false;
-            suppressVoskStatusUpdates = false;
-            StopInitializationTimeout();
-            UpdateStatus(status);
-        }
         else if (!string.IsNullOrWhiteSpace(status))
         {
-            if (!suppressVoskStatusUpdates)
-            {
-                UpdateStatus(status);
-            }
+            UpdateStatus(status);
         }
 
         RefreshButtonVisuals();
@@ -943,18 +873,6 @@ public class AIAVoskInputController : MonoBehaviour
         rmsAmplitudeThisSession = 0f;
         lastPartialTranscriptTime = -1f;
         lastPartialTranscriptText = string.Empty;
-    }
-
-    private static bool IsVoskFailureStatus(string status)
-    {
-        if (string.IsNullOrWhiteSpace(status))
-        {
-            return false;
-        }
-
-        return status.IndexOf("failed", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               status.IndexOf("could not", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               status.IndexOf("timed out", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
     private string GetSafeVoskModelPath()

--- a/Assets/AIA/AIAVoskInputController.cs
+++ b/Assets/AIA/AIAVoskInputController.cs
@@ -166,15 +166,13 @@ public class AIAVoskInputController : MonoBehaviour
         "indoor speech; RMS/noise-floor gates also apply so brief spikes are ignored.")]
     private float voiceDetectionThreshold = 0.01f;
     [SerializeField, Range(0f, 1f), Tooltip("Minimum RMS frame volume required before Vosk treats a frame as speech.")]
-    private float voiceDetectionRmsThreshold = 0.0015f;
+    private float voiceDetectionRmsThreshold = 0.002f;
     [SerializeField, Range(1f, 10f), Tooltip("Speech must be this many times louder than the learned room-noise RMS floor.")]
     private float voiceDetectionNoiseMultiplier = 2.0f;
     [SerializeField, Range(0f, 0.5f), Tooltip("Speech-like audio must persist this long before recording opens.")]
-    private float speechStartDebounceSeconds = 0.06f;
+    private float speechStartDebounceSeconds = 0.1f;
     [SerializeField, Range(0f, 0.5f), Tooltip("Quiet audio must persist this long before the silence timer can close the recording.")]
     private float speechEndDebounceSeconds = 0.12f;
-    [SerializeField, Tooltip("Send the full recording to Vosk while still using VAD to reject background noise and decide when to stop.")]
-    private bool sendAllFramesToRecognizer = true;
     [SerializeField, Tooltip(
         "Hard cap on recording length (seconds). If the user starts a recording and " +
         "the VAD never trips (e.g. mic is muted), recording is force-stopped after this many seconds " +
@@ -435,7 +433,6 @@ public class AIAVoskInputController : MonoBehaviour
             voiceProcessor.NoiseFloorMultiplier = voiceDetectionNoiseMultiplier;
             voiceProcessor.SpeechStartDebounceSeconds = speechStartDebounceSeconds;
             voiceProcessor.SpeechEndDebounceSeconds = speechEndDebounceSeconds;
-            voiceProcessor.SendAllFramesToRecognizerWhileAutoDetecting = sendAllFramesToRecognizer;
         }
         voskSpeechToText.OnStatusUpdated -= HandleVoskStatusUpdated;
         voskSpeechToText.OnTranscriptionResult -= HandleTranscriptionResult;
@@ -507,8 +504,7 @@ public class AIAVoskInputController : MonoBehaviour
 
     private void TryPreloadVosk()
     {
-        if (!preloadVoskOnStart || !CanUseVoskNativeRuntime(showWarning: false) ||
-            isVoskInitialized || isVoskInitializing || voskSpeechToText == null)
+        if (!preloadVoskOnStart || isVoskInitialized || isVoskInitializing || voskSpeechToText == null)
         {
             return;
         }
@@ -518,19 +514,6 @@ public class AIAVoskInputController : MonoBehaviour
 
     private void InitializeVosk(bool startRecordingWhenReady, bool showStatus = true)
     {
-        if (!CanUseVoskNativeRuntime(showWarning: true))
-        {
-            isVoskInitializing = false;
-            suppressVoskStatusUpdates = false;
-            StopInitializationTimeout();
-            if (showStatus)
-            {
-                UpdateStatus("Vosk recording is only available in the Android build.");
-            }
-            RefreshButtonVisuals();
-            return;
-        }
-
         if (voskSpeechToText == null)
         {
             if (showStatus)
@@ -850,11 +833,6 @@ public class AIAVoskInputController : MonoBehaviour
                 return;
             }
 
-            if (!voiceProcessor.HasDetectedSpeech)
-            {
-                return;
-            }
-
             partialTranscript = NormalizeDomainTranscript(partialTranscript);
             if (!string.Equals(partialTranscript, lastPartialTranscriptText, StringComparison.Ordinal))
             {
@@ -977,19 +955,6 @@ public class AIAVoskInputController : MonoBehaviour
         return status.IndexOf("failed", StringComparison.OrdinalIgnoreCase) >= 0 ||
                status.IndexOf("could not", StringComparison.OrdinalIgnoreCase) >= 0 ||
                status.IndexOf("timed out", StringComparison.OrdinalIgnoreCase) >= 0;
-    }
-
-    private static bool CanUseVoskNativeRuntime(bool showWarning)
-    {
-#if UNITY_ANDROID && !UNITY_EDITOR
-        return true;
-#else
-        if (showWarning)
-        {
-            Debug.LogWarning("[Vosk] Native libvosk is only imported for Android in this project; skipping Vosk initialization in this runtime.");
-        }
-        return false;
-#endif
     }
 
     private string GetSafeVoskModelPath()

--- a/Assets/Scenes/final_scenes/Mission.unity
+++ b/Assets/Scenes/final_scenes/Mission.unity
@@ -1258,12 +1258,8 @@ MonoBehaviour:
   voskModelPath: vosk-model-en-us-0.22-lgraph.zip
   maxAlternatives: 1
   initializationTimeoutSeconds: 120
-  silenceStopSeconds: 2
-  voiceDetectionThreshold: 0.012
-  voiceDetectionRmsThreshold: 0.0025
-  voiceDetectionNoiseMultiplier: 2.2
-  speechStartDebounceSeconds: 0.12
-  speechEndDebounceSeconds: 0.18
+  silenceStopSeconds: 5
+  voiceDetectionThreshold: 0.01
   maxRecordingSeconds: 15
   logTranscripts: 1
   logAudioLevels: 1

--- a/Assets/Scenes/final_scenes/Mission.unity
+++ b/Assets/Scenes/final_scenes/Mission.unity
@@ -1262,11 +1262,10 @@ MonoBehaviour:
   wakePhraseHandoffDelaySeconds: 0.35
   silenceStopSeconds: 1.8
   voiceDetectionThreshold: 0.01
-  voiceDetectionRmsThreshold: 0.0015
+  voiceDetectionRmsThreshold: 0.002
   voiceDetectionNoiseMultiplier: 2
-  speechStartDebounceSeconds: 0.06
+  speechStartDebounceSeconds: 0.1
   speechEndDebounceSeconds: 0.12
-  sendAllFramesToRecognizer: 1
   maxRecordingSeconds: 15
   logTranscripts: 1
   logAudioLevels: 1

--- a/Assets/Scenes/final_scenes/Mission.unity
+++ b/Assets/Scenes/final_scenes/Mission.unity
@@ -1258,8 +1258,6 @@ MonoBehaviour:
   voskModelPath: vosk-model-en-us-0.22-lgraph.zip
   maxAlternatives: 1
   initializationTimeoutSeconds: 120
-  preloadVoskOnStart: 1
-  wakePhraseHandoffDelaySeconds: 0.35
   silenceStopSeconds: 1.8
   voiceDetectionThreshold: 0.01
   voiceDetectionRmsThreshold: 0.002

--- a/Assets/Scenes/final_scenes/Mission.unity
+++ b/Assets/Scenes/final_scenes/Mission.unity
@@ -1258,12 +1258,12 @@ MonoBehaviour:
   voskModelPath: vosk-model-en-us-0.22-lgraph.zip
   maxAlternatives: 1
   initializationTimeoutSeconds: 120
-  silenceStopSeconds: 1.8
-  voiceDetectionThreshold: 0.01
-  voiceDetectionRmsThreshold: 0.002
-  voiceDetectionNoiseMultiplier: 2
-  speechStartDebounceSeconds: 0.1
-  speechEndDebounceSeconds: 0.12
+  silenceStopSeconds: 2
+  voiceDetectionThreshold: 0.012
+  voiceDetectionRmsThreshold: 0.0025
+  voiceDetectionNoiseMultiplier: 2.2
+  speechStartDebounceSeconds: 0.12
+  speechEndDebounceSeconds: 0.18
   maxRecordingSeconds: 15
   logTranscripts: 1
   logAudioLevels: 1

--- a/Assets/Scenes/working_scenes/AIA.unity
+++ b/Assets/Scenes/working_scenes/AIA.unity
@@ -329,12 +329,12 @@ MonoBehaviour:
   voskModelPath: vosk-model-en-us-0.22-lgraph.zip
   maxAlternatives: 1
   initializationTimeoutSeconds: 120
-  silenceStopSeconds: 1.8
-  voiceDetectionThreshold: 0.01
-  voiceDetectionRmsThreshold: 0.002
-  voiceDetectionNoiseMultiplier: 2
-  speechStartDebounceSeconds: 0.1
-  speechEndDebounceSeconds: 0.12
+  silenceStopSeconds: 2
+  voiceDetectionThreshold: 0.012
+  voiceDetectionRmsThreshold: 0.0025
+  voiceDetectionNoiseMultiplier: 2.2
+  speechStartDebounceSeconds: 0.12
+  speechEndDebounceSeconds: 0.18
   maxRecordingSeconds: 15
   logTranscripts: 1
   logAudioLevels: 1

--- a/Assets/Scenes/working_scenes/AIA.unity
+++ b/Assets/Scenes/working_scenes/AIA.unity
@@ -330,14 +330,7 @@ MonoBehaviour:
   maxAlternatives: 1
   initializationTimeoutSeconds: 120
   silenceStopSeconds: 2
-  voiceDetectionThreshold: 0.012
-  voiceDetectionRmsThreshold: 0.0025
-  voiceDetectionNoiseMultiplier: 2.2
-  speechStartDebounceSeconds: 0.12
-  speechEndDebounceSeconds: 0.18
-  maxRecordingSeconds: 15
   logTranscripts: 1
-  logAudioLevels: 1
 --- !u!1 &260001000
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/working_scenes/AIA.unity
+++ b/Assets/Scenes/working_scenes/AIA.unity
@@ -333,11 +333,10 @@ MonoBehaviour:
   wakePhraseHandoffDelaySeconds: 0.35
   silenceStopSeconds: 1.8
   voiceDetectionThreshold: 0.01
-  voiceDetectionRmsThreshold: 0.0015
+  voiceDetectionRmsThreshold: 0.002
   voiceDetectionNoiseMultiplier: 2
-  speechStartDebounceSeconds: 0.06
+  speechStartDebounceSeconds: 0.1
   speechEndDebounceSeconds: 0.12
-  sendAllFramesToRecognizer: 1
   maxRecordingSeconds: 15
   logTranscripts: 1
   logAudioLevels: 1

--- a/Assets/Scenes/working_scenes/AIA.unity
+++ b/Assets/Scenes/working_scenes/AIA.unity
@@ -329,8 +329,6 @@ MonoBehaviour:
   voskModelPath: vosk-model-en-us-0.22-lgraph.zip
   maxAlternatives: 1
   initializationTimeoutSeconds: 120
-  preloadVoskOnStart: 1
-  wakePhraseHandoffDelaySeconds: 0.35
   silenceStopSeconds: 1.8
   voiceDetectionThreshold: 0.01
   voiceDetectionRmsThreshold: 0.002

--- a/Assets/Scenes/working_scenes/Main.unity
+++ b/Assets/Scenes/working_scenes/Main.unity
@@ -338,11 +338,10 @@ MonoBehaviour:
   wakePhraseHandoffDelaySeconds: 0.35
   silenceStopSeconds: 1.8
   voiceDetectionThreshold: 0.01
-  voiceDetectionRmsThreshold: 0.0015
+  voiceDetectionRmsThreshold: 0.002
   voiceDetectionNoiseMultiplier: 2
-  speechStartDebounceSeconds: 0.06
+  speechStartDebounceSeconds: 0.1
   speechEndDebounceSeconds: 0.12
-  sendAllFramesToRecognizer: 1
   maxRecordingSeconds: 15
   logTranscripts: 1
   logAudioLevels: 1

--- a/Assets/Scenes/working_scenes/Main.unity
+++ b/Assets/Scenes/working_scenes/Main.unity
@@ -335,14 +335,7 @@ MonoBehaviour:
   maxAlternatives: 1
   initializationTimeoutSeconds: 120
   silenceStopSeconds: 2
-  voiceDetectionThreshold: 0.012
-  voiceDetectionRmsThreshold: 0.0025
-  voiceDetectionNoiseMultiplier: 2.2
-  speechStartDebounceSeconds: 0.12
-  speechEndDebounceSeconds: 0.18
-  maxRecordingSeconds: 15
   logTranscripts: 1
-  logAudioLevels: 1
 --- !u!1 &260001000
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/working_scenes/Main.unity
+++ b/Assets/Scenes/working_scenes/Main.unity
@@ -334,12 +334,12 @@ MonoBehaviour:
   voskModelPath: vosk-model-en-us-0.22-lgraph.zip
   maxAlternatives: 1
   initializationTimeoutSeconds: 120
-  silenceStopSeconds: 1.8
-  voiceDetectionThreshold: 0.01
-  voiceDetectionRmsThreshold: 0.002
-  voiceDetectionNoiseMultiplier: 2
-  speechStartDebounceSeconds: 0.1
-  speechEndDebounceSeconds: 0.12
+  silenceStopSeconds: 2
+  voiceDetectionThreshold: 0.012
+  voiceDetectionRmsThreshold: 0.0025
+  voiceDetectionNoiseMultiplier: 2.2
+  speechStartDebounceSeconds: 0.12
+  speechEndDebounceSeconds: 0.18
   maxRecordingSeconds: 15
   logTranscripts: 1
   logAudioLevels: 1

--- a/Assets/Scenes/working_scenes/Main.unity
+++ b/Assets/Scenes/working_scenes/Main.unity
@@ -334,8 +334,6 @@ MonoBehaviour:
   voskModelPath: vosk-model-en-us-0.22-lgraph.zip
   maxAlternatives: 1
   initializationTimeoutSeconds: 120
-  preloadVoskOnStart: 1
-  wakePhraseHandoffDelaySeconds: 0.35
   silenceStopSeconds: 1.8
   voiceDetectionThreshold: 0.01
   voiceDetectionRmsThreshold: 0.002

--- a/Assets/Vosk/Scripts/VoiceProcessor.cs
+++ b/Assets/Vosk/Scripts/VoiceProcessor.cs
@@ -101,7 +101,7 @@ public class VoiceProcessor : MonoBehaviour
     private float _minimumSpeakingSampleValue = 0.01f;
 
     [SerializeField, Tooltip("Minimum RMS frame volume required before audio is considered speech."), Range(0.0f, 1.0f)]
-    private float _minimumSpeakingRmsValue = 0.0015f;
+    private float _minimumSpeakingRmsValue = 0.002f;
 
     [SerializeField, Tooltip("Speech must rise this many times above the learned room-noise RMS floor."), Range(1.0f, 10.0f)]
     private float _noiseFloorMultiplier = 2.0f;
@@ -110,7 +110,7 @@ public class VoiceProcessor : MonoBehaviour
     private float _silenceTimer = 1.0f;
 
     [SerializeField, Tooltip("How long speech-like audio must persist before recording opens."), Range(0.0f, 0.5f)]
-    private float _speechStartDebounceSeconds = 0.06f;
+    private float _speechStartDebounceSeconds = 0.1f;
 
     [SerializeField, Tooltip("How long quiet audio must persist before speech is considered paused."), Range(0.0f, 0.5f)]
     private float _speechEndDebounceSeconds = 0.12f;
@@ -120,9 +120,6 @@ public class VoiceProcessor : MonoBehaviour
 
     [SerializeField, Tooltip("Auto detect speech using the volume threshold.")]
     private bool _autoDetect;
-
-    [SerializeField, Tooltip("When auto-detecting, still send every frame to Vosk. The gate only decides when speech has started and when to stop.")]
-    private bool _sendAllFramesToRecognizerWhileAutoDetecting = true;
 
     public float SilenceTimer
     {
@@ -169,15 +166,8 @@ public class VoiceProcessor : MonoBehaviour
     public float LastFrameRmsAmplitude { get; private set; }
     public float EstimatedNoiseFloorRms { get; private set; }
     public float CurrentRmsSpeechThreshold { get; private set; }
-    public bool HasDetectedSpeech { get; private set; }
 
     public bool StopRecordingAfterSilence { get; set; }
-
-    public bool SendAllFramesToRecognizerWhileAutoDetecting
-    {
-        get { return _sendAllFramesToRecognizerWhileAutoDetecting; }
-        set { _sendAllFramesToRecognizerWhileAutoDetecting = value; }
-    }
 
     private float _timeAtSilenceBegan;
     private float _timeAtSpeechCandidateBegan;
@@ -289,7 +279,6 @@ public class VoiceProcessor : MonoBehaviour
         FrameLength = frameSize;
         _audioDetected = false;
         _didDetect = false;
-        HasDetectedSpeech = false;
         _transmit = false;
         _timeAtSilenceBegan = Time.unscaledTime;
         _timeAtSpeechCandidateBegan = -1f;
@@ -398,28 +387,17 @@ public class VoiceProcessor : MonoBehaviour
             if (_autoDetect == false)
             {
                 _transmit = _audioDetected = true;
-                HasDetectedSpeech = true;
                 OnFrameCaptured?.Invoke(pcmBuffer);
             }
             else
             {
                 bool speechCandidate = IsSpeechCandidate(maxVolume, rmsVolume);
                 float now = Time.unscaledTime;
-                bool sentFrameToRecognizer = false;
                 _transmit = false;
-
-                if (_sendAllFramesToRecognizerWhileAutoDetecting && OnFrameCaptured != null)
-                {
-                    OnFrameCaptured.Invoke(pcmBuffer);
-                    sentFrameToRecognizer = true;
-                }
 
                 if (!_audioDetected)
                 {
-                    if (!_sendAllFramesToRecognizerWhileAutoDetecting)
-                    {
-                        BufferPreSpeechFrame(pcmBuffer);
-                    }
+                    BufferPreSpeechFrame(pcmBuffer);
                     UpdateNoiseFloor(rmsVolume, speechCandidate);
 
                     if (speechCandidate)
@@ -433,15 +411,11 @@ public class VoiceProcessor : MonoBehaviour
                         {
                             _audioDetected = true;
                             _didDetect = true;
-                            HasDetectedSpeech = true;
                             _transmit = true;
                             _timeAtSilenceBegan = now;
                             _timeAtQuietCandidateBegan = -1f;
-                            if (!_sendAllFramesToRecognizerWhileAutoDetecting)
-                            {
-                                FlushPreSpeechFrames();
-                                continue;
-                            }
+                            FlushPreSpeechFrames();
+                            continue;
                         }
                     }
                     else
@@ -475,7 +449,7 @@ public class VoiceProcessor : MonoBehaviour
                     }
                 }
 
-                if (!sentFrameToRecognizer && _audioDetected && OnFrameCaptured != null)
+                if (_audioDetected && OnFrameCaptured != null)
                     OnFrameCaptured.Invoke(pcmBuffer);
             }
 

--- a/Assets/Vosk/Scripts/VoiceProcessor.cs
+++ b/Assets/Vosk/Scripts/VoiceProcessor.cs
@@ -98,22 +98,22 @@ public class VoiceProcessor : MonoBehaviour
     // speech. This is only the peak gate; RMS and noise-floor gates below keep
     // single-sample spikes from resetting the silence timer.
     [SerializeField, Tooltip("The minimum volume to detect voice input for"), Range(0.0f, 1.0f)]
-    private float _minimumSpeakingSampleValue = 0.01f;
+    private float _minimumSpeakingSampleValue = 0.012f;
 
     [SerializeField, Tooltip("Minimum RMS frame volume required before audio is considered speech."), Range(0.0f, 1.0f)]
-    private float _minimumSpeakingRmsValue = 0.002f;
+    private float _minimumSpeakingRmsValue = 0.0025f;
 
     [SerializeField, Tooltip("Speech must rise this many times above the learned room-noise RMS floor."), Range(1.0f, 10.0f)]
-    private float _noiseFloorMultiplier = 2.0f;
+    private float _noiseFloorMultiplier = 2.2f;
 
     [SerializeField, Tooltip("Time in seconds of detected silence before voice request is sent")]
     private float _silenceTimer = 1.0f;
 
     [SerializeField, Tooltip("How long speech-like audio must persist before recording opens."), Range(0.0f, 0.5f)]
-    private float _speechStartDebounceSeconds = 0.1f;
+    private float _speechStartDebounceSeconds = 0.12f;
 
     [SerializeField, Tooltip("How long quiet audio must persist before speech is considered paused."), Range(0.0f, 0.5f)]
-    private float _speechEndDebounceSeconds = 0.12f;
+    private float _speechEndDebounceSeconds = 0.18f;
 
     [SerializeField, Tooltip("Audio kept before the gate opens, so the first word is not clipped."), Range(0.0f, 0.5f)]
     private float _preSpeechBufferSeconds = 0.25f;
@@ -449,7 +449,7 @@ public class VoiceProcessor : MonoBehaviour
                     }
                 }
 
-                if (_audioDetected && OnFrameCaptured != null)
+                if (_audioDetected && OnFrameCaptured != null && _transmit)
                     OnFrameCaptured.Invoke(pcmBuffer);
             }
 

--- a/Assets/Vosk/Scripts/VoiceProcessor.cs
+++ b/Assets/Vosk/Scripts/VoiceProcessor.cs
@@ -94,29 +94,16 @@ public class VoiceProcessor : MonoBehaviour
     }
 
     [Header("Voice Detection Settings")]
-    // Magic Leap 2's headset mic often peaks around 0.02-0.04 for normal indoor
-    // speech. This is only the peak gate; RMS and noise-floor gates below keep
-    // single-sample spikes from resetting the silence timer.
+    // Lowered from the upstream 0.05f default. Magic Leap 2's headset mic regularly
+    // peaks around 0.02–0.04 for normal indoor speech, so the old threshold caused
+    // Vosk to receive zero frames and return an empty transcript ("Vosk could not
+    // transcribe that recording"). 0.01 lets typical speech through while still
+    // rejecting room tone (which is usually well under 0.005).
     [SerializeField, Tooltip("The minimum volume to detect voice input for"), Range(0.0f, 1.0f)]
-    private float _minimumSpeakingSampleValue = 0.012f;
-
-    [SerializeField, Tooltip("Minimum RMS frame volume required before audio is considered speech."), Range(0.0f, 1.0f)]
-    private float _minimumSpeakingRmsValue = 0.0025f;
-
-    [SerializeField, Tooltip("Speech must rise this many times above the learned room-noise RMS floor."), Range(1.0f, 10.0f)]
-    private float _noiseFloorMultiplier = 2.2f;
+    private float _minimumSpeakingSampleValue = 0.01f;
 
     [SerializeField, Tooltip("Time in seconds of detected silence before voice request is sent")]
     private float _silenceTimer = 1.0f;
-
-    [SerializeField, Tooltip("How long speech-like audio must persist before recording opens."), Range(0.0f, 0.5f)]
-    private float _speechStartDebounceSeconds = 0.12f;
-
-    [SerializeField, Tooltip("How long quiet audio must persist before speech is considered paused."), Range(0.0f, 0.5f)]
-    private float _speechEndDebounceSeconds = 0.18f;
-
-    [SerializeField, Tooltip("Audio kept before the gate opens, so the first word is not clipped."), Range(0.0f, 0.5f)]
-    private float _preSpeechBufferSeconds = 0.25f;
 
     [SerializeField, Tooltip("Auto detect speech using the volume threshold.")]
     private bool _autoDetect;
@@ -133,50 +120,19 @@ public class VoiceProcessor : MonoBehaviour
         set { _minimumSpeakingSampleValue = Mathf.Clamp01(value); }
     }
 
-    public float MinimumSpeakingRmsValue
-    {
-        get { return _minimumSpeakingRmsValue; }
-        set { _minimumSpeakingRmsValue = Mathf.Clamp01(value); }
-    }
-
-    public float NoiseFloorMultiplier
-    {
-        get { return _noiseFloorMultiplier; }
-        set { _noiseFloorMultiplier = Mathf.Max(1f, value); }
-    }
-
-    public float SpeechStartDebounceSeconds
-    {
-        get { return _speechStartDebounceSeconds; }
-        set { _speechStartDebounceSeconds = Mathf.Clamp(value, 0f, 0.5f); }
-    }
-
-    public float SpeechEndDebounceSeconds
-    {
-        get { return _speechEndDebounceSeconds; }
-        set { _speechEndDebounceSeconds = Mathf.Clamp(value, 0f, 0.5f); }
-    }
-
     /// <summary>
     /// Highest absolute sample amplitude observed in the most recent capture frame.
     /// Useful for diagnosing "no audio detected" issues: if this never exceeds the
     /// threshold during a recording, the mic is too quiet or the threshold too high.
     /// </summary>
     public float LastFrameMaxAmplitude { get; private set; }
-    public float LastFrameRmsAmplitude { get; private set; }
-    public float EstimatedNoiseFloorRms { get; private set; }
-    public float CurrentRmsSpeechThreshold { get; private set; }
 
     public bool StopRecordingAfterSilence { get; set; }
 
     private float _timeAtSilenceBegan;
-    private float _timeAtSpeechCandidateBegan;
-    private float _timeAtQuietCandidateBegan;
     private bool _audioDetected;
     private bool _didDetect;
     private bool _transmit;
-    private readonly Queue<short[]> _preSpeechFrames = new Queue<short[]>();
-    private int _maxPreSpeechFrames = 1;
 
 
     AudioClip _audioClip;
@@ -280,13 +236,7 @@ public class VoiceProcessor : MonoBehaviour
         _audioDetected = false;
         _didDetect = false;
         _transmit = false;
-        _timeAtSilenceBegan = Time.unscaledTime;
-        _timeAtSpeechCandidateBegan = -1f;
-        _timeAtQuietCandidateBegan = -1f;
-        _preSpeechFrames.Clear();
-        _maxPreSpeechFrames = Mathf.Max(1, Mathf.CeilToInt(_preSpeechBufferSeconds / ((float) frameSize / sampleRate)));
-        EstimatedNoiseFloorRms = Mathf.Max(0.0001f, _minimumSpeakingRmsValue / _noiseFloorMultiplier);
-        CurrentRmsSpeechThreshold = _minimumSpeakingRmsValue;
+        _timeAtSilenceBegan = Time.time;
 
         _audioClip = Microphone.Start(CurrentDeviceName, true, 1, sampleRate);
 
@@ -355,8 +305,8 @@ public class VoiceProcessor : MonoBehaviour
                 _audioClip.GetData(startClipSamples, 0);
 
                 // combine to form full frame
-                Array.Copy(endClipSamples, 0, sampleBuffer, 0, numSamplesClipEnd);
-                Array.Copy(startClipSamples, 0, sampleBuffer, numSamplesClipEnd, numSamplesClipStart);
+                Buffer.BlockCopy(endClipSamples, 0, sampleBuffer, 0, numSamplesClipEnd);
+                Buffer.BlockCopy(startClipSamples, 0, sampleBuffer, numSamplesClipEnd, numSamplesClipStart);
             }
             else
             {
@@ -364,96 +314,56 @@ public class VoiceProcessor : MonoBehaviour
             }
 
             startReadPos = endReadPos % _audioClip.samples;
-
-            // Convert once per frame and use both peak and RMS energy. Peak-only
-            // detection is easily fooled by clicks, wind, or short headset spikes.
-            float maxVolume = 0.0f;
-            float sumSquares = 0.0f;
-            short[] pcmBuffer = new short[sampleBuffer.Length];
-            for (int i = 0; i < sampleBuffer.Length; i++)
-            {
-                float abs = sampleBuffer[i] < 0 ? -sampleBuffer[i] : sampleBuffer[i];
-                if (abs > maxVolume)
-                {
-                    maxVolume = abs;
-                }
-                sumSquares += sampleBuffer[i] * sampleBuffer[i];
-                pcmBuffer[i] = (short) Math.Floor(sampleBuffer[i] * short.MaxValue);
-            }
-            float rmsVolume = Mathf.Sqrt(sumSquares / sampleBuffer.Length);
-            LastFrameMaxAmplitude = maxVolume;
-            LastFrameRmsAmplitude = rmsVolume;
-
             if (_autoDetect == false)
             {
-                _transmit = _audioDetected = true;
-                OnFrameCaptured?.Invoke(pcmBuffer);
+                _transmit =_audioDetected = true;
             }
             else
             {
-                bool speechCandidate = IsSpeechCandidate(maxVolume, rmsVolume);
-                float now = Time.unscaledTime;
-                _transmit = false;
-
-                if (!_audioDetected)
+                // Absolute value: speech waveforms swing both positive and negative,
+                // so checking sampleBuffer[i] > maxVolume alone misses every trough.
+                float maxVolume = 0.0f;
+                for (int i = 0; i < sampleBuffer.Length; i++)
                 {
-                    BufferPreSpeechFrame(pcmBuffer);
-                    UpdateNoiseFloor(rmsVolume, speechCandidate);
-
-                    if (speechCandidate)
+                    float abs = sampleBuffer[i] < 0 ? -sampleBuffer[i] : sampleBuffer[i];
+                    if (abs > maxVolume)
                     {
-                        if (_timeAtSpeechCandidateBegan < 0f)
-                        {
-                            _timeAtSpeechCandidateBegan = now;
-                        }
+                        maxVolume = abs;
+                    }
+                }
+                LastFrameMaxAmplitude = maxVolume;
 
-                        if (now - _timeAtSpeechCandidateBegan >= _speechStartDebounceSeconds)
-                        {
-                            _audioDetected = true;
-                            _didDetect = true;
-                            _transmit = true;
-                            _timeAtSilenceBegan = now;
-                            _timeAtQuietCandidateBegan = -1f;
-                            FlushPreSpeechFrames();
-                            continue;
-                        }
-                    }
-                    else
-                    {
-                        _timeAtSpeechCandidateBegan = -1f;
-                    }
+                if (maxVolume >= _minimumSpeakingSampleValue)
+                {
+                    _transmit= _audioDetected = true;
+                    _timeAtSilenceBegan = Time.time;
                 }
                 else
                 {
-                    if (speechCandidate)
-                    {
-                        _transmit = true;
-                        _timeAtSilenceBegan = now;
-                        _timeAtQuietCandidateBegan = -1f;
-                    }
-                    else
-                    {
-                        if (_timeAtQuietCandidateBegan < 0f)
-                        {
-                            _timeAtQuietCandidateBegan = now;
-                        }
+                    _transmit = false;
 
-                        if (now - _timeAtQuietCandidateBegan < _speechEndDebounceSeconds)
-                        {
-                            _transmit = true;
-                        }
-                        else if (now - _timeAtSilenceBegan > _silenceTimer)
-                        {
-                            _audioDetected = false;
-                        }
+                    if (_audioDetected && Time.time - _timeAtSilenceBegan > _silenceTimer)
+                    {
+                        _audioDetected = false;
                     }
                 }
-
-                if (_audioDetected && OnFrameCaptured != null && _transmit)
-                    OnFrameCaptured.Invoke(pcmBuffer);
             }
 
-            if (!_audioDetected)
+            if (_audioDetected)
+            {
+                _didDetect = true;
+                // converts to 16-bit int samples
+                short[] pcmBuffer = new short[sampleBuffer.Length];
+                for (int i = 0; i < FrameLength; i++)
+                {
+                    pcmBuffer[i] = (short) Math.Floor(sampleBuffer[i] * short.MaxValue);
+                }
+
+                // raise buffer event
+                if (OnFrameCaptured != null && _transmit)
+                    OnFrameCaptured.Invoke(pcmBuffer);
+            }
+            else
             {
                 if (_didDetect)
                 {
@@ -476,41 +386,5 @@ public class VoiceProcessor : MonoBehaviour
         _recordDataCoroutine = null;
         if (RestartRecording != null)
             RestartRecording.Invoke();
-    }
-
-    private bool IsSpeechCandidate(float maxVolume, float rmsVolume)
-    {
-        CurrentRmsSpeechThreshold = Mathf.Max(_minimumSpeakingRmsValue, EstimatedNoiseFloorRms * _noiseFloorMultiplier);
-        return maxVolume >= _minimumSpeakingSampleValue && rmsVolume >= CurrentRmsSpeechThreshold;
-    }
-
-    private void UpdateNoiseFloor(float rmsVolume, bool speechCandidate)
-    {
-        if (speechCandidate || _audioDetected)
-        {
-            return;
-        }
-
-        float smoothing = rmsVolume > EstimatedNoiseFloorRms ? 0.08f : 0.25f;
-        EstimatedNoiseFloorRms = Mathf.Lerp(EstimatedNoiseFloorRms, rmsVolume, smoothing);
-    }
-
-    private void BufferPreSpeechFrame(short[] pcmBuffer)
-    {
-        short[] copy = new short[pcmBuffer.Length];
-        Array.Copy(pcmBuffer, copy, pcmBuffer.Length);
-        _preSpeechFrames.Enqueue(copy);
-        while (_preSpeechFrames.Count > _maxPreSpeechFrames)
-        {
-            _preSpeechFrames.Dequeue();
-        }
-    }
-
-    private void FlushPreSpeechFrames()
-    {
-        while (_preSpeechFrames.Count > 0)
-        {
-            OnFrameCaptured?.Invoke(_preSpeechFrames.Dequeue());
-        }
     }
 }

--- a/Assets/Vosk/Scripts/VoskSpeechToText.cs
+++ b/Assets/Vosk/Scripts/VoskSpeechToText.cs
@@ -178,7 +178,6 @@ public class VoskSpeechToText : MonoBehaviour
 		if (startMicrophone)
 		{
 			_running = true;
-			ClearQueuedRecognitionData();
 			ConfigureVoiceProcessorSilenceDetection();
 			VoiceProcessor.StartRecording(autoDetect: AutoStopRecordingOnSilence);
 			if (!VoiceProcessor.IsRecording)
@@ -394,7 +393,6 @@ public class VoskSpeechToText : MonoBehaviour
 
 			_running = true;
 			_lastPartialResult = "";
-			ClearQueuedRecognitionData();
 			ConfigureVoiceProcessorSilenceDetection();
 			VoiceProcessor.StartRecording(autoDetect: AutoStopRecordingOnSilence);
 			Task.Run(ThreadedWork).ConfigureAwait(false);
@@ -438,7 +436,6 @@ public class VoskSpeechToText : MonoBehaviour
 	{
 		Debug.Log("Stopped");
 		_running = false;
-		DrainPendingAudio();
 		EmitFinalResult();
 	}
 
@@ -457,11 +454,6 @@ public class VoskSpeechToText : MonoBehaviour
 					string result = null;
 					lock (_recognizerLock)
 					{
-						if (!_recognizerReady || _recognizer == null)
-						{
-							continue;
-						}
-
 						hasResult = _recognizer.AcceptWaveform(voiceResult, voiceResult.Length);
 						if (hasResult && !EmitResultsOnlyOnStop)
 						{
@@ -486,7 +478,7 @@ public class VoskSpeechToText : MonoBehaviour
 				else
 				{
 					// Wait for some data
-					await Task.Delay(20);
+					await Task.Delay(100);
 				}
 			}
 		}
@@ -510,7 +502,6 @@ public class VoskSpeechToText : MonoBehaviour
 
 		try
 		{
-			DrainPendingAudio();
 			string finalResult;
 			lock (_recognizerLock)
 			{
@@ -529,29 +520,6 @@ public class VoskSpeechToText : MonoBehaviour
 			Debug.LogError($"[Vosk] Failed to emit final result: {exception}");
 			OnStatusUpdated?.Invoke("Vosk failed to process recording.");
 		}
-	}
-
-	private void DrainPendingAudio()
-	{
-		while (_threadedBufferQueue.TryDequeue(out short[] voiceResult))
-		{
-			lock (_recognizerLock)
-			{
-				if (!_recognizerReady || _recognizer == null)
-				{
-					return;
-				}
-
-				_recognizer.AcceptWaveform(voiceResult, voiceResult.Length);
-			}
-		}
-	}
-
-	private void ClearQueuedRecognitionData()
-	{
-		while (_threadedBufferQueue.TryDequeue(out _)) { }
-		while (_threadedResultQueue.TryDequeue(out _)) { }
-		while (_threadedPartialResultQueue.TryDequeue(out _)) { }
 	}
 
 

--- a/Assets/Vosk/Scripts/VoskSpeechToText.cs
+++ b/Assets/Vosk/Scripts/VoskSpeechToText.cs
@@ -93,7 +93,6 @@ public class VoskSpeechToText : MonoBehaviour
 	private readonly ConcurrentQueue<string> _threadedResultQueue = new ConcurrentQueue<string>();
 	private readonly ConcurrentQueue<string> _threadedPartialResultQueue = new ConcurrentQueue<string>();
 	private string _lastPartialResult = "";
-	private string _lastEndpointResult = "";
 
 
 
@@ -464,13 +463,9 @@ public class VoskSpeechToText : MonoBehaviour
 						}
 
 						hasResult = _recognizer.AcceptWaveform(voiceResult, voiceResult.Length);
-						if (hasResult)
+						if (hasResult && !EmitResultsOnlyOnStop)
 						{
 							result = _recognizer.Result();
-							if (EmitResultsOnlyOnStop && HasRecognitionText(result))
-							{
-								_lastEndpointResult = result;
-							}
 						}
 						else if (!hasResult)
 						{
@@ -478,7 +473,7 @@ public class VoskSpeechToText : MonoBehaviour
 						}
 					}
 
-					if (hasResult && !EmitResultsOnlyOnStop && !string.IsNullOrWhiteSpace(result))
+					if (hasResult && !string.IsNullOrWhiteSpace(result))
 					{
 						_threadedResultQueue.Enqueue(result);
 					}
@@ -517,22 +512,13 @@ public class VoskSpeechToText : MonoBehaviour
 		{
 			DrainPendingAudio();
 			string finalResult;
-			string endpointResult;
 			lock (_recognizerLock)
 			{
 				finalResult = _recognizer.FinalResult();
-				endpointResult = _lastEndpointResult;
-				_lastEndpointResult = "";
 				_recognizer.Dispose();
 				_recognizer = null;
 				_recognizerReady = false;
 				_lastPartialResult = "";
-			}
-
-			if (!HasRecognitionText(finalResult) && HasRecognitionText(endpointResult))
-			{
-				Debug.Log($"[Vosk] Final result was empty; using last endpoint result: {endpointResult}");
-				finalResult = endpointResult;
 			}
 
 			Debug.Log($"[Vosk] Final result: {finalResult}");
@@ -556,15 +542,7 @@ public class VoskSpeechToText : MonoBehaviour
 					return;
 				}
 
-				bool hasResult = _recognizer.AcceptWaveform(voiceResult, voiceResult.Length);
-				if (hasResult)
-				{
-					string endpointResult = _recognizer.Result();
-					if (HasRecognitionText(endpointResult))
-					{
-						_lastEndpointResult = endpointResult;
-					}
-				}
+				_recognizer.AcceptWaveform(voiceResult, voiceResult.Length);
 			}
 		}
 	}
@@ -574,38 +552,6 @@ public class VoskSpeechToText : MonoBehaviour
 		while (_threadedBufferQueue.TryDequeue(out _)) { }
 		while (_threadedResultQueue.TryDequeue(out _)) { }
 		while (_threadedPartialResultQueue.TryDequeue(out _)) { }
-		_lastEndpointResult = "";
-	}
-
-	private static bool HasRecognitionText(string json)
-	{
-		if (string.IsNullOrWhiteSpace(json))
-		{
-			return false;
-		}
-
-		try
-		{
-			var result = new RecognitionResult(json);
-			if (result.Phrases == null)
-			{
-				return false;
-			}
-
-			for (int i = 0; i < result.Phrases.Length; i++)
-			{
-				if (!string.IsNullOrWhiteSpace(result.Phrases[i]?.Text))
-				{
-					return true;
-				}
-			}
-		}
-		catch (Exception)
-		{
-			return true;
-		}
-
-		return false;
 	}
 
 


### PR DESCRIPTION
## Summary

Reverts four Vosk-tuning commits that broke AIA. The last known working state of AIA was at `fff35973` (hibaa8, "add stop recording button"). After that, Astrowebdeving landed four commits tuning Vosk that left AIA broken. This PR restores the Vosk-related files to their `fff35973` state while keeping all other work on `main` (warnings UI, LTV repair flow, AIA-panel merges) intact.

## Reverted commits (newest first)

| Hash | Title |
|------|-------|
| `72da600b` | Improve Vosk transcription capture |
| `ce872432` | Preload Vosk before wake recording |
| `43d8ea17` | Retune Vosk cutoff and sensitivity |
| `2c83e81a` | Tune Vosk voice cutoff and noise gating |

Each revert is its own commit so the history names exactly what's being undone.

## Verification

After this PR:

- `Assets/AIA/AIAVoskInputController.cs` — byte-identical to `fff35973`
- `Assets/Vosk/Scripts/VoiceProcessor.cs` — byte-identical to `fff35973`
- `Assets/Vosk/Scripts/VoskSpeechToText.cs` — byte-identical to `fff35973`
- `Assets/Scenes/working_scenes/AIA.unity` — byte-identical to `fff35973`
- `Assets/Scenes/working_scenes/Main.unity` — byte-identical to `fff35973`
- `Assets/Scenes/final_scenes/Mission.unity` — Vosk component tuning reverted to `fff35973`; Andrew Bonilla's warnings UI work (`da91c514`) preserved
- All other files unchanged

## Preserved (NOT reverted)

- `da91c514` Andrew Bonilla — Working basic warnings without full procedures
- `ed4f5e01` Richard Li — LTV: ERM-first priority, voice step advance, TSS polling fixes, dummy feeder
- `bfa44dec` Hiba Altaf — Merge PR #86 (warnings_ranges)
- `048abeb5` / `ab273e0a` Hiba Altaf — Merge PRs #87, #89 (AIA-panel wrappers; the payload commits are reverted above)
- `49419046` Grace Xu — Merge PR #88 (LTV-checks-rich)

## Test plan

- [ ] Open the project in Unity. Confirm AIA wake/recording flow works as it did at `fff35973`.
- [ ] Confirm warnings UI (Andrew's work) still renders in Mission/Egress scenes.
- [ ] Confirm LTV repair flow (Richard's work) still works.
- [ ] Confirm no Vosk-related scene references are broken in `Mission.unity` / `AIA.unity` / `Main.unity`.