### PR TITLE
Vitals Panel World-Space Follow

### DIFF
--- a/Assets/Scenes/final_scenes/Mission.unity
+++ b/Assets/Scenes/final_scenes/Mission.unity
@@ -1022,8 +1022,6 @@ MonoBehaviour:
   showWaypoints: 1
   verboseDebug: 1
   logIntervalSeconds: 1
-  showTerrainOverlay: 0
-  overlayAlpha: 0.55
 --- !u!114 &224362101
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2363,7 +2361,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e763e881eb0df45e1a1978531d3091c7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  tssHost: 172.20.10.2
+  tssHost: 192.168.50.110
   tssPort: 14141
   pollIntervalSeconds: 1
   udpTimeoutMs: 500
@@ -3809,8 +3807,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 168, y: 0}
+  m_SizeDelta: {x: 336, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &5000030042
 CanvasRenderer:
@@ -4153,6 +4151,48 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8800000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8800000002}
+  m_Layer: 5
+  m_Name: HUDRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8800000002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8800000001}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9100101}
+  - {fileID: 809889382}
+  - {fileID: 850000011}
+  - {fileID: 850000021}
+  - {fileID: 850000031}
+  - {fileID: 850000041}
+  - {fileID: 5000030001}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &8800000010
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4234,45 +4274,3 @@ SceneRoots:
   - {fileID: 5000020000}
   - {fileID: 9200001}
   - {fileID: 8800000002}
---- !u!1 &8800000001
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8800000002}
-  m_Layer: 5
-  m_Name: HUDRoot
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &8800000002
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8800000001}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 9100101}
-  - {fileID: 809889382}
-  - {fileID: 850000011}
-  - {fileID: 850000021}
-  - {fileID: 850000031}
-  - {fileID: 850000041}
-  - {fileID: 5000030001}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/UI-Prefab/Prefab/GrabbableVitalsMenu.prefab
+++ b/Assets/UI-Prefab/Prefab/GrabbableVitalsMenu.prefab
@@ -3053,6 +3053,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cameraTransform: {fileID: 0}
   smoothTime: 0.15
+  continuouslyFollowCamera: 1
 --- !u!1 &8869387029982448835
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/UI-Scripts/AdjustableFollowUI.cs
+++ b/Assets/UI-Scripts/AdjustableFollowUI.cs
@@ -50,15 +50,14 @@ public class AdjustableFollowUI : MonoBehaviour
         if (isGrabbed) return;
         if (cameraTransform == null) return;
 
-        Vector3 cameraEuler = cameraTransform.eulerAngles;
-        Quaternion yawRotation = Quaternion.Euler(0f, cameraEuler.y, 0f);
-
-        Vector3 targetPosition = cameraTransform.position + (yawRotation * targetOffset);
+        // Follow the camera's world position using a fixed world-space offset.
+        // Head rotation is intentionally ignored — the panel stays where it was
+        // placed in the world and only moves when the user physically moves.
+        Vector3 targetPosition = cameraTransform.position + targetOffset;
         transform.position = Vector3.SmoothDamp(transform.position, targetPosition, ref velocity, smoothTime);
 
-        Vector3 lookAtPos = cameraTransform.position;
-        lookAtPos.y = transform.position.y;
-        transform.LookAt(2f * transform.position - lookAtPos);
+        // Always face the user regardless of panel position.
+        transform.LookAt(2f * transform.position - cameraTransform.position);
     }
 
     private void OnGrab(SelectEnterEventArgs args)
@@ -77,8 +76,7 @@ public class AdjustableFollowUI : MonoBehaviour
     {
         if (cameraTransform == null) return;
 
-        Vector3 cameraEuler = cameraTransform.eulerAngles;
-        Quaternion inverseYaw = Quaternion.Inverse(Quaternion.Euler(0f, cameraEuler.y, 0f));
-        targetOffset = inverseYaw * (transform.position - cameraTransform.position);
+        // Store the offset in world space so head rotation doesn't affect panel position.
+        targetOffset = transform.position - cameraTransform.position;
     }
 }

--- a/Assets/UI-Scripts/AdjustableFollowUI.cs
+++ b/Assets/UI-Scripts/AdjustableFollowUI.cs
@@ -44,6 +44,19 @@ public class AdjustableFollowUI : MonoBehaviour
             UpdateOffset();
     }
 
+    private void OnEnable()
+    {
+        // Ensure camera reference is ready (Start may not have run yet on first enable).
+        if (cameraTransform == null && Camera.main != null)
+            cameraTransform = Camera.main.transform;
+
+        // VitalsButton positions the panel before SetActive(true), so by the time
+        // OnEnable fires the transform is already at the correct front-of-camera
+        // position — recalculating the offset here locks it in from that new spot.
+        if (continuouslyFollowCamera)
+            UpdateOffset();
+    }
+
     private void Update()
     {
         if (!continuouslyFollowCamera) return;


### PR DESCRIPTION
This PR allows the vitals panel to follow the user in world-space, an improvement from the gliding based on head rotation which limited the user's vision.

The vitals panel is grabbable, then draggable, and can be placed in some position. When the user moves, the panel glides along but remains in that position. It won't align based on your rotation to maintain the relative offset, it simply remains in the set position; if I placed the vitals in front of me, then turned 180 degrees and kept walking forward, then I can turn around and see the vitals still behind me in the same distance. If I turned 90 degrees left and walked for a while, I should be able to turn right and still see it there. It maintains the world-space position, floating alongside you to maintain your distance to it, it doesn't float to turn with your head. Toggling the vitals button will reset its position to in front of you.

To test, turn on the vitals and interact with the grabbable panel.